### PR TITLE
rewrite packet handling to use Threading Channels

### DIFF
--- a/LibreMetaverse/LibreMetaverse.csproj
+++ b/LibreMetaverse/LibreMetaverse.csproj
@@ -57,6 +57,7 @@
     <PackageReference Include="System.Drawing.Common" Version="4.6.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Channels" Version="4.6.0" />
     <PackageReference Include="XmlRpcCore" Version="3.0.0" />
     <PackageReference Include="zlib.net-mutliplatform" Version="1.0.4" />
   </ItemGroup>

--- a/LibreMetaverse/NetworkManager.cs
+++ b/LibreMetaverse/NetworkManager.cs
@@ -30,6 +30,8 @@ using System.Threading;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 using OpenMetaverse.Packets;
 using OpenMetaverse.Interfaces;
 using OpenMetaverse.Messages.Linden;
@@ -321,10 +323,10 @@ namespace OpenMetaverse
         public bool Connected => connected;
 
         /// <summary>Number of packets in the incoming queue</summary>
-        public int InboxCount => _packetInbox.Count;
+        public int InboxCount => _packetInboxCount;
 
         /// <summary>Number of packets in the outgoing queue</summary>
-        public int OutboxCount => _packetOutbox.Count;
+        public int OutboxCount => _packetOutboxCount;
 
         #endregion Properties
 
@@ -335,17 +337,20 @@ namespace OpenMetaverse
         internal CapsEventDictionary CapsEvents;
         /// <summary>Handlers for incoming packets</summary>
         internal PacketEventDictionary PacketEvents;
+
         /// <summary>Incoming packets that are awaiting handling</summary>
-        private readonly ConcurrentQueue<IncomingPacket> _packetInbox = new ConcurrentQueue<IncomingPacket>();
-        private readonly SemaphoreSlim _packetInboxDataAvailable = new SemaphoreSlim(0);
+        private Channel<IncomingPacket> _packetInbox;
+
+        private int _packetInboxCount = 0;
+
         /// <summary>Outgoing packets that are awaiting handling</summary>
-        private readonly ConcurrentQueue<OutgoingPacket> _packetOutbox = new ConcurrentQueue<OutgoingPacket>();
-        private readonly SemaphoreSlim _packetOutboxDataAvailable = new SemaphoreSlim(0);
+        private Channel<OutgoingPacket> _packetOutbox;
+
+        private int _packetOutboxCount = 0;
 
         private GridClient Client;
         private Timer DisconnectTimer;
         private bool connected;
-        private CancellationTokenSource _cancellationTokenSource = null;
 
         /// <summary>
         /// Default constructor
@@ -494,8 +499,8 @@ namespace OpenMetaverse
         /// <param name="packet">Incoming packet to process</param>
         public void EnqueueIncoming(IncomingPacket packet)
         {
-            _packetInbox.Enqueue(packet);
-            _packetInboxDataAvailable.Release();
+            if (_packetInbox.Writer.TryWrite(packet))
+                Interlocked.Increment(ref _packetInboxCount);
         }
         
         /// <summary>
@@ -504,8 +509,8 @@ namespace OpenMetaverse
         /// <param name="packet">Incoming packet to process</param>
         public void EnqueueOutgoing(OutgoingPacket packet)
         {
-            _packetOutbox.Enqueue(packet);
-            _packetOutboxDataAvailable.Release();
+            if (_packetOutbox.Writer.TryWrite(packet))
+                Interlocked.Increment(ref _packetOutboxCount);
         }
 
         /// <summary>
@@ -550,30 +555,23 @@ namespace OpenMetaverse
                 // connection fails
                 lock (Simulators) Simulators.Add(simulator);
             }
+            
+            if (_packetInbox == null || _packetOutbox == null)
+            {
+                var options = new UnboundedChannelOptions() {SingleReader = true};
+                
+                _packetInbox = Channel.CreateUnbounded<IncomingPacket>(options);
+                _packetOutbox = Channel.CreateUnbounded<OutgoingPacket>(options);
+
+                Task.Run(IncomingPacketHandler);
+                Task.Run(OutgoingPacketHandler);
+            }
 
             if (!simulator.Connected)
             {
-                if (!connected)
-                {
-                    // Mark that we are connecting/connected to the grid
-                    // 
-                    connected = true;
-                    _cancellationTokenSource = new CancellationTokenSource();
-
-                    // Start the packet decoding thread
-                    Thread decodeThread = new Thread(IncomingPacketHandler)
-                    {
-                        Name = "Incoming UDP packet dispatcher"
-                    };
-                    decodeThread.Start();
-
-                    // Start the packet sending thread
-                    Thread sendThread = new Thread(OutgoingPacketHandler)
-                    {
-                        Name = "Outgoing UDP packet dispatcher"
-                    };
-                    sendThread.Start();
-                }
+                // Mark that we are connecting/connected to the grid
+                // 
+                connected = true;
 
                 // raise the SimConnecting event and allow any event
                 // subscribers to cancel the connection
@@ -731,13 +729,6 @@ namespace OpenMetaverse
                 DisconnectTimer = null;
             }
 
-            if (_cancellationTokenSource != null)
-            {
-                _cancellationTokenSource.Cancel();
-                _cancellationTokenSource.Dispose();
-                _cancellationTokenSource = null;
-            }
-
             // This will catch a Logout when the client is not logged in
             if (CurrentSim == null || !connected)
             {
@@ -843,13 +834,12 @@ namespace OpenMetaverse
                     OnSimDisconnected(new SimDisconnectedEventArgs(CurrentSim, type));
                 }
             }
+            
+            _packetInbox.Writer.Complete();
+            _packetOutbox.Writer.Complete();
 
-            // Clear out all of the packets that never had time to process
-            // NOTE: .NET Standard 2.1 has .Clear() but 2.0 doesn't... so let's just keep Dequeuing till it's empty
-            while (!_packetInbox.IsEmpty)
-                _packetInbox.TryDequeue(out _);
-            while (!_packetOutbox.IsEmpty)
-                _packetOutbox.TryDequeue(out _);
+            _packetInbox = null;
+            _packetOutbox = null;
 
             connected = false;
 
@@ -900,41 +890,29 @@ namespace OpenMetaverse
             }
         }
 
-        private void OutgoingPacketHandler()
+        private async Task OutgoingPacketHandler()
         {
-            try
-            {
-                var token = _cancellationTokenSource?.Token ?? throw new NullReferenceException();
-                while (connected)
-                {
-                    _packetOutboxDataAvailable.Wait(token);
+            var reader = _packetOutbox.Reader;
 
-                    if (!_packetOutbox.TryDequeue(out var outgoingPacket)) continue;
+            while (await reader.WaitToReadAsync() && connected)
+            {
+                while (reader.TryRead(out var outgoingPacket))
+                {
                     var simulator = outgoingPacket.Simulator;
 
                     simulator.SendPacketFinal(outgoingPacket);
                 }
             }
-            catch (ObjectDisposedException e)
-            {
-                Logger.Log("OutgoingPacketHandler thread was cancelled", Helpers.LogLevel.Debug, e);
-            }
-            catch (OperationCanceledException e)
-            {
-                Logger.Log("OutgoingPacketHandler thread was cancelled", Helpers.LogLevel.Debug, e);
-            }
         }
 
-        private void IncomingPacketHandler()
+        private async Task IncomingPacketHandler()
         {
-            try
-            {
-                var token = _cancellationTokenSource?.Token ?? throw new NullReferenceException();
-                while (connected)
-                {
-                    _packetInboxDataAvailable.Wait(token);
+            var reader = _packetInbox.Reader;
 
-                    if (!_packetInbox.TryDequeue(out var incomingPacket)) continue;
+            while (await reader.WaitToReadAsync() && connected)
+            {
+                while (reader.TryRead(out var incomingPacket))
+                {
                     var packet = incomingPacket.Packet;
                     var simulator = incomingPacket.Simulator;
 
@@ -951,14 +929,6 @@ namespace OpenMetaverse
                     // Fire the callback(s), if any
                     PacketEvents.RaiseEvent(packet.Type, packet, simulator);
                 }
-            }
-            catch (ObjectDisposedException e)
-            {
-                Logger.Log("IncomingPacketHandler thread was cancelled", Helpers.LogLevel.Debug, e);
-            }
-            catch (OperationCanceledException e)
-            {
-                Logger.Log("IncomingPacketHandler thread was cancelled", Helpers.LogLevel.Debug, e);
             }
         }
 

--- a/LibreMetaverse/NetworkManager.cs
+++ b/LibreMetaverse/NetworkManager.cs
@@ -840,6 +840,9 @@ namespace OpenMetaverse
 
             _packetInbox = null;
             _packetOutbox = null;
+            
+            Interlocked.Exchange(ref _packetInboxCount, 0);
+            Interlocked.Exchange(ref _packetOutboxCount, 0);
 
             connected = false;
 
@@ -898,8 +901,9 @@ namespace OpenMetaverse
             {
                 while (reader.TryRead(out var outgoingPacket))
                 {
+                    Interlocked.Decrement(ref _packetOutboxCount);
+                    
                     var simulator = outgoingPacket.Simulator;
-
                     simulator.SendPacketFinal(outgoingPacket);
                 }
             }
@@ -913,6 +917,8 @@ namespace OpenMetaverse
             {
                 while (reader.TryRead(out var incomingPacket))
                 {
+                    Interlocked.Decrement(ref _packetInboxCount);
+                    
                     var packet = incomingPacket.Packet;
                     var simulator = incomingPacket.Simulator;
 


### PR DESCRIPTION
This should prevent unnecessary wait looping internally and lower the packets time to start processing.

Seems to fix WoofBot's packet processing hot path.

We can drop the nuget entry once we move to .NET Core + .NET Standard Extensions.