### PR TITLE
Update XmlRpcCore to move to HttpClient implementation

### DIFF
--- a/LibreMetaverse/Caps.cs
+++ b/LibreMetaverse/Caps.cs
@@ -336,13 +336,15 @@ namespace OpenMetaverse
                 // try generic decoder next which takes a caps event and tries to match it to an existing packet
                 if (body.Type == OSDType.Map)
                 {
-                    OSDMap map = (OSDMap)body;
+                    OSDMap map = body;
                     Packet packet = Packet.BuildPacket(eventName, map);
                     if (packet != null)
                     {
-                        NetworkManager.IncomingPacket incomingPacket;
-                        incomingPacket.Simulator = Simulator;
-                        incomingPacket.Packet = packet;
+                        var incomingPacket = new NetworkManager.IncomingPacket
+                        {
+                            Simulator = Simulator,
+                            Packet = packet
+                        };
 
                         Logger.DebugLog("Serializing " + packet.Type + " capability with generic handler", 
                             Simulator.Client);

--- a/LibreMetaverse/LibreMetaverse.csproj
+++ b/LibreMetaverse/LibreMetaverse.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.0" />
-    <PackageReference Include="XmlRpcCore" Version="3.0.0" />
+    <PackageReference Include="XmlRpcCore" Version="3.1.0.50" />
     <PackageReference Include="zlib.net-mutliplatform" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup>

--- a/LibreMetaverse/Login.cs
+++ b/LibreMetaverse/Login.cs
@@ -1235,9 +1235,10 @@ namespace OpenMetaverse
                         {
                             var cts = new CancellationTokenSource();
                             cts.CancelAfter(cc.Timeout);
-                            LoginReplyXmlRpcHandler(
-                                await HTTP_CLIENT.PostAsXmlRpcAsync(cc.URI, request, cts.Token),
-                                loginParams);
+                            var loginResponse = await HTTP_CLIENT.PostAsXmlRpcAsync(cc.URI, request, cts.Token);
+                            cts.Dispose();
+                            
+                            LoginReplyXmlRpcHandler(loginResponse, loginParams);
                         }
                         catch (Exception e)
                         {

--- a/LibreMetaverse/Login.cs
+++ b/LibreMetaverse/Login.cs
@@ -34,10 +34,12 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.NetworkInformation;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace OpenMetaverse
 {
@@ -900,6 +902,13 @@ namespace OpenMetaverse
         #endregion
 
         #region Private Members
+
+        public static readonly HttpClient HTTP_CLIENT = new HttpClient(new HttpClientHandler()
+        {
+            ServerCertificateCustomValidationCallback = delegate { return true; },
+            AllowAutoRedirect = true
+        });
+        
         private LoginParams CurrentContext = null;
         private AutoResetEvent LoginEvent = new AutoResetEvent(false);
         private LoginStatus InternalStatusCode = LoginStatus.None;
@@ -1220,20 +1229,22 @@ namespace OpenMetaverse
                     XmlRpcRequest request = new XmlRpcRequest(CurrentContext.MethodName, loginArray);
                     var cc = CurrentContext;
                     // Start the request
-                    ThreadPool.QueueUserWorkItem((_) =>
+                    Task.Run(async () =>
+                    {
+                        try
                         {
-                            try
-                            {
-                                LoginReplyXmlRpcHandler(
-                                    request.Send(cc.URI, cc.Timeout),
-                                    loginParams);
-                            }
-                            catch (Exception e)
-                            {
-                                UpdateLoginStatus(LoginStatus.Failed,
-                                    "Error opening the login server connection: " + e.Message);
-                            }
-                        });
+                            var cts = new CancellationTokenSource();
+                            cts.CancelAfter(cc.Timeout);
+                            LoginReplyXmlRpcHandler(
+                                await HTTP_CLIENT.PostAsXmlRpcAsync(cc.URI, request, cts.Token),
+                                loginParams);
+                        }
+                        catch (Exception e)
+                        {
+                            UpdateLoginStatus(LoginStatus.Failed,
+                                "Error opening the login server connection: " + e.Message);
+                        }
+                    });
                 }
                 catch (Exception e)
                 {

--- a/LibreMetaverse/NetworkManager.cs
+++ b/LibreMetaverse/NetworkManager.cs
@@ -75,18 +75,13 @@ namespace OpenMetaverse
         /// Holds a simulator reference and a decoded packet, these structs are put in
         /// the packet inbox for event handling
         /// </summary>
-        public struct IncomingPacket
+        public class IncomingPacket
         {
             /// <summary>Reference to the simulator that this packet came from</summary>
             public Simulator Simulator;
+
             /// <summary>Packet that needs to be processed</summary>
             public Packet Packet;
-
-            public IncomingPacket(Simulator simulator, Packet packet)
-            {
-                Simulator = simulator;
-                Packet = packet;
-            }
         }
         
         /// <summary>

--- a/LibreMetaverse/NetworkManager.cs
+++ b/LibreMetaverse/NetworkManager.cs
@@ -30,6 +30,7 @@ using System.Threading;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using OpenMetaverse.Packets;

--- a/LibreMetaverse/Simulator.cs
+++ b/LibreMetaverse/Simulator.cs
@@ -1169,9 +1169,11 @@ namespace OpenMetaverse
 
             #region Inbox Insertion
 
-            NetworkManager.IncomingPacket incomingPacket;
-            incomingPacket.Simulator = this;
-            incomingPacket.Packet = packet;
+            var incomingPacket = new NetworkManager.IncomingPacket
+            {
+                Simulator = this,
+                Packet = packet
+            };
 
             Network.EnqueueIncoming(incomingPacket);
 

--- a/Programs/GridProxy/GridProxy.cs
+++ b/Programs/GridProxy/GridProxy.cs
@@ -38,6 +38,7 @@ using System.Text;
 using System.Threading;
 using System.Net.Sockets;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Text.RegularExpressions;
 using OpenMetaverse;
 using OpenMetaverse.Http;
@@ -186,6 +187,8 @@ namespace GridProxy
     {
         public ProxyConfig proxyConfig;
         private string loginURI;
+
+        private static readonly HttpClient HttpClient = new HttpClient();
         
         static List<string> BinaryResponseCaps = new List<string>()
         {
@@ -1129,8 +1132,9 @@ namespace GridProxy
                 try
                 {
                     // forward the XML-RPC request to the server
-                    response = (XmlRpcResponse)request.Send(proxyConfig.remoteLoginUri.ToString(),
-                        30 * 1000); // 30 second timeout
+                    var cts = new CancellationTokenSource();
+                    cts.CancelAfter(TimeSpan.FromSeconds(30)); // 30 second timeout
+                    response = HttpClient.PostAsXmlRpcAsync(proxyConfig.remoteLoginUri, request, cts.Token).Result;
                 }
                 catch (Exception e)
                 {

--- a/Programs/GridProxy/GridProxy.cs
+++ b/Programs/GridProxy/GridProxy.cs
@@ -1135,6 +1135,7 @@ namespace GridProxy
                     var cts = new CancellationTokenSource();
                     cts.CancelAfter(TimeSpan.FromSeconds(30)); // 30 second timeout
                     response = HttpClient.PostAsXmlRpcAsync(proxyConfig.remoteLoginUri, request, cts.Token).Result;
+                    cts.Dispose();
                 }
                 catch (Exception e)
                 {

--- a/Programs/GridProxy/GridProxy.csproj
+++ b/Programs/GridProxy/GridProxy.csproj
@@ -51,7 +51,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
-    <PackageReference Include="XmlRpcCore" Version="3.0.0" />
+    <PackageReference Include="XmlRpcCore" Version="3.1.0.50" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\LibreMetaverseTypes\LibreMetaverse.Types.csproj" />


### PR DESCRIPTION
HTTP_CLIENT is left public for now to allow us to move more things over to HttpClient.