### PR TITLE
Large Chat support

### DIFF
--- a/LibreMetaverse/Helpers.cs
+++ b/LibreMetaverse/Helpers.cs
@@ -86,6 +86,20 @@ namespace OpenMetaverse
             return (short)Math.Round(offset);
         }
 
+        public static IEnumerable<string> SplitBy(this string str, int chunkLength)
+        {
+            if (String.IsNullOrEmpty(str)) throw new ArgumentException();
+            if (chunkLength < 1) throw new ArgumentException();
+
+            for (int i = 0; i < str.Length; i += chunkLength)
+            {
+                if (chunkLength + i > str.Length)
+                    chunkLength = str.Length - i;
+
+                yield return str.Substring(i, chunkLength);
+            }
+        }
+
         /// <summary>
         /// 
         /// </summary>


### PR DESCRIPTION
The current Chat command found in AgentManager.cs errors if you send a message that is to large.

Fix:
split the message into chunks of 900chars (with optional chunk_grouping details)