### PR TITLE
run callback even if asset transfer failed

### DIFF
--- a/LibreMetaverse/AssetManager.cs
+++ b/LibreMetaverse/AssetManager.cs
@@ -690,6 +690,7 @@ namespace OpenMetaverse
                         {
                             transfer.Success = false;
                             transfer.Status = StatusCode.Error;
+                            callback(transfer, null);
                         }
 
                     }


### PR DESCRIPTION
Hello, When downloading an asset via HTTP and the download fails, the callback is not called at all even if the proper parameters are set. This results in long waiting times for the request to time out. The pull request will just call the callback in case the asset transfer failed. Please apply if useful.

Greets.