### PR TITLE
Increment System.Threading.Channels to latest version number

### DIFF
--- a/LibreMetaverse/LibreMetaverse.csproj
+++ b/LibreMetaverse/LibreMetaverse.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Channels" Version="4.7.0" />
+    <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
     <PackageReference Include="XmlRpcCore" Version="3.1.2.77" />
     <PackageReference Include="zlib.net-mutliplatform" Version="1.0.4" />
   </ItemGroup>


### PR DESCRIPTION
This causes conflicts in programs if you do not specify System.Threading.Channels as a dependency, and you compile with the runtime flag to produce a self-contained executable. If you manually include the dependency in the main project at the lower version everything is fine, this just makes it easier for everyone as this new version does not appear to break anything.