### PR TITLE
Xbake issues on non secondlife grids

### DIFF
--- a/LibreMetaverse/Imaging/BakeLayer.cs
+++ b/LibreMetaverse/Imaging/BakeLayer.cs
@@ -473,9 +473,15 @@ namespace OpenMetaverse.Imaging
 
                     if (sourceHasColor)
                     {
-                        bakedRed[i] = (byte)((bakedRed[i] * alphaInv + sourceRed[i] * alpha) >> 8);
-                        bakedGreen[i] = (byte)((bakedGreen[i] * alphaInv + sourceGreen[i] * alpha) >> 8);
-                        bakedBlue[i] = (byte)((bakedBlue[i] * alphaInv + sourceBlue[i] * alpha) >> 8);
+                        if ((bakedRed.Length > i) && (bakedGreen.Length > i) && (bakedBlue.Length > i))
+                        {
+                            if ((sourceRed.Length > i) && (sourceGreen.Length > i) && (sourceBlue.Length > i))
+                            {
+                                bakedRed[i] = (byte)((bakedRed[i] * alphaInv + sourceRed[i] * alpha) >> 8);
+                                bakedGreen[i] = (byte)((bakedGreen[i] * alphaInv + sourceGreen[i] * alpha) >> 8);
+                                bakedBlue[i] = (byte)((bakedBlue[i] * alphaInv + sourceBlue[i] * alpha) >> 8);
+                            }
+                        }
                     }
 
                     if (addSourceAlpha)

--- a/LibreMetaverse/Imaging/BakeLayer.cs
+++ b/LibreMetaverse/Imaging/BakeLayer.cs
@@ -40,7 +40,6 @@ namespace OpenMetaverse.Imaging
     /// </summary>
     public class Baker
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         #region Properties
         /// <summary>Final baked texture</summary>
         public AssetTexture BakedTexture => bakedTexture;
@@ -333,7 +332,7 @@ namespace OpenMetaverse.Imaging
             }
 
             // Apply any alpha wearable textures to make parts of the avatar disappear
-            m_log.DebugFormat("[XBakes]: Number of alpha wearable textures: {0}", alphaWearableTextures.Count);
+            Logger.Log("[XBakes]: Number of alpha wearable textures: " + alphaWearableTextures.Count.ToString(), Helpers.LogLevel.Debug);
             foreach (ManagedImage img in alphaWearableTextures)
                 AddAlpha(bakedTexture.Image, img);
 
@@ -465,8 +464,11 @@ namespace OpenMetaverse.Imaging
                 {
                     if (sourceHasAlpha)
                     {
-                        alpha = sourceAlpha[i];
-                        alphaInv = (byte)(Byte.MaxValue - alpha);
+                        if (sourceAlpha.Length > i)
+                        {
+                            alpha = sourceAlpha[i];
+                            alphaInv = (byte)(Byte.MaxValue - alpha);
+                        }
                     }
 
                     if (sourceHasColor)

--- a/LibreMetaverse/_Packets_.cs
+++ b/LibreMetaverse/_Packets_.cs
@@ -12821,7 +12821,12 @@ namespace OpenMetaverse.Packets
             for (int j = 0; j < WearableData.Length; j++) { WearableData[j].ToBytes(bytes, ref i); }
             ObjectData.ToBytes(bytes, ref i);
             bytes[i++] = (byte)VisualParam.Length;
-            for (int j = 0; j < VisualParam.Length; j++) { VisualParam[j].ToBytes(bytes, ref i); }
+            for (int j = 0; j < VisualParam.Length; j++) {
+                if (VisualParam[j] != null)
+                {
+                    VisualParam[j].ToBytes(bytes, ref i);
+                }
+            }
             if (Header.AckList != null && Header.AckList.Length > 0) { Header.AcksToBytes(bytes, ref i); }
             return bytes;
         }

--- a/LibreMetaverse/_Packets_.cs
+++ b/LibreMetaverse/_Packets_.cs
@@ -12798,9 +12798,20 @@ namespace OpenMetaverse.Packets
             length += AgentData.Length;
             length += ObjectData.Length;
             length++;
-            for (int j = 0; j < WearableData.Length; j++) { length += WearableData[j].Length; }
+            for (int j = 0; j < WearableData.Length; j++) {
+                if (WearableData[j] != null)
+                {
+                    length += WearableData[j].Length;
+                }
+            }
             length++;
-            for (int j = 0; j < VisualParam.Length; j++) { length += VisualParam[j].Length; }
+            for (int j = 0; j < VisualParam.Length; j++) 
+            {
+                if (VisualParam[j] != null)
+                {
+                    length += VisualParam[j].Length;
+                }
+            }
             if (Header.AckList != null && Header.AckList.Length > 0) { length += Header.AckList.Length * 4 + 1; }
             byte[] bytes = new byte[length];
             int i = 0;


### PR DESCRIPTION
WearableData array can be null in some cases
VisualParam array can be null in some cases
XBakes ignores logging level and creates its own logger, redirected to Logger.Log
sourceAlpha.Length can be less than i in some cases leading to fun bugs