### PR TITLE
Update BakeLayer.cs

### DIFF
--- a/LibreMetaverse/Imaging/BakeLayer.cs
+++ b/LibreMetaverse/Imaging/BakeLayer.cs
@@ -30,7 +30,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Drawing;
 using OpenMetaverse.Assets;
-using log4net;
 
 namespace OpenMetaverse.Imaging
 {
@@ -40,7 +39,6 @@ namespace OpenMetaverse.Imaging
     /// </summary>
     public class Baker
     {
-        private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         #region Properties
         /// <summary>Final baked texture</summary>
         public AssetTexture BakedTexture => bakedTexture;
@@ -333,7 +331,7 @@ namespace OpenMetaverse.Imaging
             }
 
             // Apply any alpha wearable textures to make parts of the avatar disappear
-            m_log.DebugFormat("[XBakes]: Number of alpha wearable textures: {0}", alphaWearableTextures.Count);
+            Logger.Log("[XBakes]: Number of alpha wearable textures: " + alphaWearableTextures.Count.ToString(), Helpers.LogLevel.Debug);
             foreach (ManagedImage img in alphaWearableTextures)
                 AddAlpha(bakedTexture.Image, img);
 
@@ -463,29 +461,48 @@ namespace OpenMetaverse.Imaging
             {
                 for (int x = 0; x < bakeWidth; x++)
                 {
+                    alpha = 0;
+                    alphaInv = 0;
                     if (sourceHasAlpha)
                     {
-                        alpha = sourceAlpha[i];
-                        alphaInv = (byte)(Byte.MaxValue - alpha);
+                        if (sourceAlpha.Length > i)
+                        {
+                            alpha = sourceAlpha[i];
+                            alphaInv = (byte)(Byte.MaxValue - alpha);
+                        }
                     }
 
                     if (sourceHasColor)
                     {
-                        bakedRed[i] = (byte)((bakedRed[i] * alphaInv + sourceRed[i] * alpha) >> 8);
-                        bakedGreen[i] = (byte)((bakedGreen[i] * alphaInv + sourceGreen[i] * alpha) >> 8);
-                        bakedBlue[i] = (byte)((bakedBlue[i] * alphaInv + sourceBlue[i] * alpha) >> 8);
+                        if ((bakedRed.Length > i) && (bakedGreen.Length > i) && (bakedBlue.Length > i))
+                        {
+                            if ((sourceRed.Length > i) && (sourceGreen.Length > i) && (sourceBlue.Length > i))
+                            {
+                                bakedRed[i] = (byte)((bakedRed[i] * alphaInv + sourceRed[i] * alpha) >> 8);
+                                bakedGreen[i] = (byte)((bakedGreen[i] * alphaInv + sourceGreen[i] * alpha) >> 8);
+                                bakedBlue[i] = (byte)((bakedBlue[i] * alphaInv + sourceBlue[i] * alpha) >> 8);
+                            }
+                        }
                     }
 
                     if (addSourceAlpha)
                     {
-                        if (sourceAlpha[i] < bakedAlpha[i])
+                        if ((sourceAlpha.Length > i) && (bakedAlpha.Length > i))
                         {
-                            bakedAlpha[i] = sourceAlpha[i];
+                            if (sourceAlpha[i] < bakedAlpha[i])
+                            {
+                                bakedAlpha[i] = sourceAlpha[i];
+                            }
                         }
                     }
 
                     if (sourceHasBump)
-                        bakedBump[i] = sourceBump[i];
+                    {
+                        if (sourceBump.Length > i)
+                        {
+                            bakedBump[i] = sourceBump[i];
+                        }
+                    }
 
                     ++i;
                 }


### PR DESCRIPTION
switchs logger to "Logger.Log" so it follows logging levels
adds bounds checks for the following values sourceAlpha, bakedRed, bakedGreen, bakedBlue, sourceRed, sourceGreen, sourceBlue, bakedAlpha, sourceBump so if something goes wrong it should not outright crash

Maybe we could add a one time error to this to detect when it happens or switch it to a try catch

this pull request does not include the changes to _packet_.cs as I was unable to safely check where that was being created :(