### PR TITLE
add a call to RequestFetchInventory

### DIFF
--- a/LibreMetaverse/InventoryManager.cs
+++ b/LibreMetaverse/InventoryManager.cs
@@ -3582,6 +3582,7 @@ namespace OpenMetaverse
                                 break;
                         }
                         imp.MessageBlock.BinaryBucket = args.FolderID.GetBytes();
+                        RequestFetchInventory(objectID, e.IM.ToAgentID);
                     }
                     else
                     {


### PR DESCRIPTION
adds a call to RequestFetchInventory when you accept inventory transfer so the Inventory.ItemReceived will fire as expected.