### PR TITLE
Allow rebaking after a specific delay

### DIFF
--- a/LibreMetaverse/AppearanceManager.cs
+++ b/LibreMetaverse/AppearanceManager.cs
@@ -2362,13 +2362,21 @@ namespace OpenMetaverse
             return set;
         }
 
-        private void DelayedRequestSetAppearance()
+        /// <summary>
+        /// Request appearance update after delay. Rewrites existing appearance
+        /// rebake timer.
+        /// </summary>
+        /// <param name="due">the rebake delay (ms)</param>
+        public void DelayedRequestSetAppearance(int due = REBAKE_DELAY)
         {
             if (RebakeScheduleTimer == null)
             {
                 RebakeScheduleTimer = new Timer(RebakeScheduleTimerTick);
             }
-            try { RebakeScheduleTimer.Change(REBAKE_DELAY, Timeout.Infinite); }
+
+            try {
+                RebakeScheduleTimer.Change(due, Timeout.Infinite);
+            }
             catch { }
         }
 


### PR DESCRIPTION
Sometimes it is necessary to rebake faster than REBAKE_DELAY. Moving REBAKE_DELAY to Settings is inconvenient (it would make the whole library rebake faster). 

DelayedRequestSetAppearance method made public with a due argument which allows forcing faster rebake.