### PR TITLE
adds a alias for Update parcel

### DIFF
--- a/LibreMetaverse/ParcelManager.cs
+++ b/LibreMetaverse/ParcelManager.cs
@@ -607,6 +607,17 @@ namespace OpenMetaverse
         }
 
         /// <summary>
+        /// Update the parcel (in the current sim)
+        /// </summary>
+        /// <param name="client">Client message originates from</param>
+        /// <param name="wantReply">Whether we want the simulator to confirm
+        /// the update with a reply packet or not [default false]</param>
+        public void Update(GridClient client, bool wantReply = false)
+        {
+            Update(client, client.Network.CurrentSim, wantReply);
+        }
+
+        /// <summary>
         /// Update the simulator with any local changes to this Parcel object
         /// </summary>
         /// <param name="client">Client message originates from</param>


### PR DESCRIPTION
the update command now requires both the client and the target sim [good if updating remote parcels] but most of the time you will be updating the sim the bot is on. this alias fetchs the sim from the client and also sets wantReply to false by default.