### PR TITLE
Allow test client cd command to use spaces

### DIFF
--- a/Programs/examples/TestClient/Commands/Inventory/ChangeDirectoryCommand.cs
+++ b/Programs/examples/TestClient/Commands/Inventory/ChangeDirectoryCommand.cs
@@ -16,8 +16,6 @@ namespace OpenMetaverse.TestClient.Commands.Inventory.Shell
         {
             Inventory = Client.Inventory.Store;
 
-            if (args.Length > 1)
-                return "Usage: cd [path-to-folder]";
             string pathStr = "";
             string[] path = null;
             if (args.Length == 0)
@@ -30,6 +28,11 @@ namespace OpenMetaverse.TestClient.Commands.Inventory.Shell
                 pathStr = args[0];
                 path = pathStr.Split(new[] { '/' });
                 // Use '/' as a path seperator.
+            }
+            else
+            {
+                pathStr = System.String.Join(" ", args);
+                path = pathStr.Split(new[] { '/' });
             }
             InventoryFolder currentFolder = Client.CurrentDirectory;
             if (pathStr.StartsWith("/"))


### PR DESCRIPTION
Inventory items can have spaces in their names, which conflicts with the cd command in testclient since it uses spaces as arg separators.