### PR TITLE
Fixs related to radegast issue #69 - 3D Scene viewer no longer works after updating to v2.45

### DIFF
--- a/LibreMetaverse/BVHDecoder.cs
+++ b/LibreMetaverse/BVHDecoder.cs
@@ -181,7 +181,7 @@ namespace OpenMetaverse
             for (var j = i; j < data.Length; j++)
             {
                 char spot = Convert.ToChar(data[j]);
-                if (spot == '\n')
+                if (spot == '\0')
                 {
                     endpos = j;
                     break;

--- a/PrimMesher/PrimMesher.cs
+++ b/PrimMesher/PrimMesher.cs
@@ -1058,7 +1058,9 @@ namespace LibreMetaverse.PrimMesher
 
             if (needFaces)
                 copy.faces.AddRange(faces);
-            if (copy.calcVertexNormals == calcVertexNormals)
+
+            copy.calcVertexNormals = calcVertexNormals;
+            if (calcVertexNormals)
             {
                 copy.vertexNormals.AddRange(vertexNormals);
                 copy.faceNormal = faceNormal;

--- a/PrimMesher/SculptMap.cs
+++ b/PrimMesher/SculptMap.cs
@@ -121,6 +121,10 @@ namespace LibreMetaverse.PrimMesher
             }
             catch (Exception e)
             {
+                if (needsScaling)
+                {
+                    bm.Dispose();
+                }
                 throw new Exception("Caught exception processing byte arrays in SculptMap(): e: " + e);
             }
 
@@ -128,6 +132,11 @@ namespace LibreMetaverse.PrimMesher
             {
                 width++;
                 height++;
+            }
+
+            if (needsScaling)
+            {
+                bm.Dispose();
             }
         }
 
@@ -167,7 +176,6 @@ namespace LibreMetaverse.PrimMesher
             var info = new SKImageInfo(destWidth, destHeight);
             var scaledImage = new SKBitmap(info);
             srcImage.ScalePixels(scaledImage.PeekPixels(), new SKSamplingOptions(SKFilterMode.Linear));
-            srcImage.Dispose();
             return scaledImage;
         }
     }


### PR DESCRIPTION
**Fixed crash in BVHDecoder** - ReadBytesUntilNull was reading until newline instead of null

**Fixed crash in PrimMesher** - Profile::Copy was not copying correctly:
- The original expression was:
```if ((copy.calcVertexNormals = this.calcVertexNormals) == true)```
	 
- then it got refactored to:
```if (copy.calcVertexNormals = calcVertexNormals)```
		
- which looked like a classic error, so it was incorrectly changed to:
```if (copy.calcVertexNormals == calcVertexNormals)```

**Fixed crash in PrmiMesher** - SculptMap::ScaleImage was disposing live SKBitmap's
- SculptMap takes in a SKBitmap, but then incorrectly assumes full ownership over the lifetime of it by disposing it in ScaleImage. This causes issues if the caller assumes it has control over the lifetime of the object, such as radegast and how it stores these SKBitmaps in a cache for re-use. 