### PR TITLE
Replace all file serilization with MessagePack

### DIFF
--- a/LibreMetaverse/AppearanceManager.cs
+++ b/LibreMetaverse/AppearanceManager.cs
@@ -127,7 +127,6 @@ namespace OpenMetaverse
 
     #endregion Enums
 
-    [Serializable]
     public class AppearanceManagerException : Exception
     {
         public AppearanceManagerException(string message)

--- a/LibreMetaverse/Formatters/UUIDFormatter.cs
+++ b/LibreMetaverse/Formatters/UUIDFormatter.cs
@@ -1,0 +1,31 @@
+﻿using MessagePack;
+using MessagePack.Formatters;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenMetaverse.Formatters
+{
+    public class UUIDFormatter : IMessagePackFormatter<UUID>
+    {
+        public static readonly UUIDFormatter Instance = new UUIDFormatter();
+
+        public void Serialize(ref MessagePackWriter writer, UUID value, MessagePackSerializerOptions options)
+        {
+            writer.Write(value.GetBytes());
+        }
+
+        public UUID Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        {
+            var sequence = reader.ReadBytes();
+            if (sequence == null)
+            {
+                throw new MessagePackSerializationException("Invalid UUID");
+            }
+
+            var bytes = sequence.Value.ToArray();
+            return new UUID(bytes, 0);
+        }
+    }
+}

--- a/LibreMetaverse/Inventory.cs
+++ b/LibreMetaverse/Inventory.cs
@@ -25,14 +25,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-using MessagePack;
-using MessagePack.Formatters;
-using MessagePack.Resolvers;
 using System;
-using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace OpenMetaverse
@@ -354,23 +349,6 @@ namespace OpenMetaverse
             Items.Clear();
         }
 
-        private MessagePackSerializerOptions GetSerializerOptions()
-        {
-            var resolver = MessagePack.Resolvers.CompositeResolver.Create(
-                new List<IMessagePackFormatter>()
-                {
-                    Formatters.UUIDFormatter.Instance,
-                },
-                new List<IFormatterResolver>
-                {
-                    StandardResolver.Instance,
-                }
-            );
-
-            return MessagePackSerializerOptions
-                .Standard
-                .WithResolver(resolver);
-        }
 
         /// <summary>
         /// Saves the current inventory structure to a cache file
@@ -378,134 +356,17 @@ namespace OpenMetaverse
         /// <param name="filename">Name of the cache file to save to</param>
         public void SaveToDisk(string filename)
         {
-            try
-            {
-                using (Stream stream = File.Open(filename, FileMode.Create))
-                {
-                    lock (Items)
-                    {
-                        Logger.Log($"Caching {Items.Count} inventory items to {filename}", Helpers.LogLevel.Info);
-
-                        var options = GetSerializerOptions();
-                        var items = Items.Values.ToList();
-
-                        MessagePackSerializer.Serialize(stream, items, options);
-                    }
-                }
-	        }
-            catch (Exception e)
-            {
-                Logger.Log("Error saving inventory cache to disk", Helpers.LogLevel.Error, e);
-            }
+            InventoryCache.SaveToDisk(filename, Items);
         }
 
         /// <summary>
         /// Loads in inventory cache file into the inventory structure. Note only valid to call after login has been successful.
         /// </summary>
         /// <param name="filename">Name of the cache file to load</param>
-        /// <returns>The number of inventory items successfully reconstructed into the inventory node tree</returns>
+        /// <returns>The number of inventory items successfully reconstructed into the inventory node tree, or -1 on error</returns>
         public int RestoreFromDisk(string filename)
         {
-            var cacheNodes = new List<InventoryNode>();
-
-            try
-            {
-                if (!File.Exists(filename))
-                {
-                    return -1;
-                }
-
-                using (var stream = File.Open(filename, FileMode.Open))
-                {
-                    var options = GetSerializerOptions();
-
-                    cacheNodes = MessagePackSerializer.Deserialize<List<InventoryNode>>(stream, options);
-                }
-            }
-            catch (Exception e)
-            {
-                Logger.Log("Error accessing inventory cache file", Helpers.LogLevel.Error, e);
-                return -1;
-            }
-
-            Logger.Log($"Read {cacheNodes.Count} items from inventory cache file", Helpers.LogLevel.Info);
-
-            var dirtyFolders = new HashSet<UUID>();
-
-            // First pass: process InventoryFolders
-            foreach (var cacheNode in cacheNodes)
-            {
-                if(!(cacheNode.Data is InventoryFolder cacheFolder))
-                {
-                    continue;
-                }
-
-                if (cacheNode.Data.ParentUUID == UUID.Zero)
-                {
-                    //We don't need the root nodes "My Inventory" etc as they will already exist for the correct
-                    // user of this cache.
-                    continue;
-                }
-
-                if (!Items.TryGetValue(cacheNode.Data.UUID, out var serverNode))
-                {
-                    // This is an orphaned folder that no longer exists on the server.
-                    continue;
-                }
-
-                var serverFolder = (InventoryFolder)serverNode.Data;
-                serverNode.NeedsUpdate = cacheFolder.Version != serverFolder.Version;
-
-                if (serverNode.NeedsUpdate)
-                {
-                    Logger.DebugLog($"Inventory Cache/Server version mismatch on {cacheNode.Data.Name} {cacheFolder.Version} vs {serverFolder.Version}");
-                    dirtyFolders.Add(cacheNode.Data.UUID);
-                }
-            }
-
-            // Second pass: process InventoryItems
-            var itemCount = 0;
-            foreach (var cacheNode in cacheNodes)
-            {
-                if (!(cacheNode.Data is InventoryItem cacheItem))
-                {
-                    // Only process InventoryItems
-                    continue;
-                }
-
-                if (!Items.TryGetValue(cacheNode.Data.ParentUUID, out var serverParentNode))
-                {
-                    // This item does not have a parent in our known inventory. The folder was probably deleted on the server
-                    // and our cache is old
-                    continue;
-                }
-
-                if(dirtyFolders.Contains(serverParentNode.Data.UUID))
-                {
-                    // This item belongs to a folder that has been marked as dirty, so it too is dirty and must be skipped
-                    continue;
-                }
-
-                if(Items.ContainsKey(cacheItem.UUID))
-                {
-                    // This item was already added to our Items store, likely added from previous server requests during this session
-                    continue;
-                }
-
-                if (!Items.TryAdd(cacheItem.UUID, cacheNode))
-                {
-                    Logger.Log($"Failed to add cache item node {cacheItem.Name} with parent {serverParentNode.Data.Name}", Helpers.LogLevel.Info);
-                    continue;
-                }
-
-                // Add this cached InventoryItem node to the parent
-                cacheNode.Parent = serverParentNode;
-                serverParentNode.Nodes.Add(cacheItem.UUID, cacheNode);
-                itemCount++;
-            }
-
-            Logger.Log($"Reassembled {itemCount} items from inventory cache file", Helpers.LogLevel.Info);
-            return itemCount;
+            return InventoryCache.RestoreFromDisk(filename, Items);
         }
 
         #region Operators

--- a/LibreMetaverse/InventoryBase.cs
+++ b/LibreMetaverse/InventoryBase.cs
@@ -26,87 +26,56 @@
  */
 
 using System;
-using System.Runtime.Serialization;
 using OpenMetaverse.StructuredData;
-#if NET7_0_OR_GREATER
-using MemoryPack;
-#endif
+using MessagePack;
 
 namespace OpenMetaverse
 {
     /// <summary>
     /// Base Class for Inventory Items
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-    [MemoryPackUnion(0, typeof(InventoryFolder))]
-    [MemoryPackUnion(1, typeof(InventoryItem))]
-    [MemoryPackUnion(2, typeof(InventoryAnimation))]
-    [MemoryPackUnion(3, typeof(InventoryAttachment))]
-    [MemoryPackUnion(4, typeof(InventoryCallingCard))]
-    [MemoryPackUnion(5, typeof(InventoryCategory))]
-    [MemoryPackUnion(6, typeof(InventoryGesture))]
-    [MemoryPackUnion(7, typeof(InventoryLSL))]
-    [MemoryPackUnion(8, typeof(InventoryLandmark))]
-    [MemoryPackUnion(9, typeof(InventoryMaterial))]
-    [MemoryPackUnion(10, typeof(InventoryNotecard))]
-    [MemoryPackUnion(11, typeof(InventoryObject))]
-    [MemoryPackUnion(12, typeof(InventorySettings))]
-    [MemoryPackUnion(13, typeof(InventorySnapshot))]
-    [MemoryPackUnion(14, typeof(InventorySound))]
-    [MemoryPackUnion(15, typeof(InventoryTexture))]
-    [MemoryPackUnion(16, typeof(InventoryWearable))]
-#endif
-    public abstract partial class InventoryBase : ISerializable
+    [MessagePackObject]
+    [Union(0, typeof(InventoryFolder))]
+    [Union(1, typeof(InventoryItem))]
+    [Union(2, typeof(InventoryAnimation))]
+    [Union(3, typeof(InventoryAttachment))]
+    [Union(4, typeof(InventoryCallingCard))]
+    [Union(5, typeof(InventoryCategory))]
+    [Union(6, typeof(InventoryGesture))]
+    [Union(7, typeof(InventoryLSL))]
+    [Union(8, typeof(InventoryLandmark))]
+    [Union(9, typeof(InventoryMaterial))]
+    [Union(10, typeof(InventoryNotecard))]
+    [Union(11, typeof(InventoryObject))]
+    [Union(12, typeof(InventorySettings))]
+    [Union(13, typeof(InventorySnapshot))]
+    [Union(14, typeof(InventorySound))]
+    [Union(15, typeof(InventoryTexture))]
+    [Union(16, typeof(InventoryWearable))]
+    public abstract partial class InventoryBase
     {
         /// <summary><see cref="OpenMetaverse.UUID"/> of item/folder</summary>
+        [Key("UUID")]
         public UUID UUID;
         /// <summary><see cref="OpenMetaverse.UUID"/> of parent folder</summary>
+        [Key("ParentUUID")]
         public UUID ParentUUID;
         /// <summary>Name of item/folder</summary>
+        [Key("Name")]
         public string Name;
         /// <summary>Item/Folder Owners <see cref="OpenMetaverse.UUID"/></summary>
+        [Key("OwnerID")]
         public UUID OwnerID;
 
         /// <summary>
         /// Constructor, takes an itemID as a parameter
         /// </summary>
         /// <param name="UUID">The <see cref="OpenMetaverse.UUID"/> of the item</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         protected InventoryBase(UUID UUID)
         {
             if (UUID == UUID.Zero)
                 Logger.Log("Initializing an InventoryBase with UUID.Zero", Helpers.LogLevel.Warning);
             this.UUID = UUID;
-        }
-
-        /// <summary>
-        /// Get object data
-        /// </summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
-        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            info.AddValue("UUID", UUID);
-            info.AddValue("ParentUUID", ParentUUID);
-            info.AddValue("Name", Name);
-            info.AddValue("OwnerID", OwnerID);
-        }
-
-        /// <summary>
-        /// Inventory base ctor
-        /// </summary>
-        /// <param name="info"></param>
-        /// <param name="ctxt"></param>
-        protected InventoryBase(SerializationInfo info, StreamingContext ctxt)
-        {
-            UUID = (UUID)info.GetValue("UUID", typeof(UUID));
-            ParentUUID = (UUID)info.GetValue("ParentUUID", typeof(UUID));
-            Name = (string)info.GetValue("Name", typeof(string));
-            OwnerID = (UUID)info.GetValue("OwnerID", typeof(UUID));
         }
 
         /// <summary>
@@ -152,10 +121,7 @@ namespace OpenMetaverse
     /// <summary>
     /// An Item in Inventory
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventoryItem : InventoryBase
     {
         public override string ToString()
@@ -163,45 +129,58 @@ namespace OpenMetaverse
             return $"{AssetType} {AssetUUID} ({InventoryType} {UUID}) '{Name}'/'{Description}' {Permissions}";
         }
         /// <summary><see cref="UUID"/> of the underlying asset</summary>
+        [Key("AssetUUID")]
         public UUID AssetUUID;
         /// <summary>Combined <see cref="OpenMetaverse.Permissions"/> of the item</summary>
+        [Key("Permissions")]
         public Permissions Permissions;
         /// <summary><see cref="OpenMetaverse.AssetType"/> of the underlying asset</summary>
+        [Key("AssetType")]
         public AssetType AssetType;
         /// <summary><see cref="OpenMetaverse.InventoryType"/> of the item</summary>
+        [Key("InventoryType")]
         public InventoryType InventoryType;
         /// <summary><see cref="UUID"/> of the creator of the item</summary>
+        [Key("CreatorID")]
         public UUID CreatorID;
         /// <summary>Description of the item</summary>
+        [Key("Description")]
         public string Description;
         /// <summary><see cref="Group"/>s <see cref="UUID"/> the item is owned by</summary>
+        [Key("GroupID")]
         public UUID GroupID;
         /// <summary>If true, item is owned by a group</summary>
+        [Key("GroupOwned")]
         public bool GroupOwned;
         /// <summary>Price the item can be purchased for</summary>
+        [Key("SalePrice")]
         public int SalePrice;
         /// <summary><see cref="OpenMetaverse.SaleType"/> of the item</summary>
+        [Key("SaleType")]
         public SaleType SaleType;
         /// <summary>Combined flags from <see cref="InventoryItemFlags"/></summary>
+        [Key("Flags")]
         public uint Flags;
+
         /// <summary>Time and date the inventory item was created, stored as
         /// UTC (Coordinated Universal Time)</summary>
+        [Key("CreationDate")]
         public DateTime CreationDate;
         /// <summary>Used to update the AssetID in requests sent to the server</summary>
+        [Key("TransactionID")]
         public UUID TransactionID;
         /// <summary><see cref="UUID"/> of the previous owner of the item</summary>
+        [Key("LastOwnerID")]
         public UUID LastOwnerID;
 
         /// <summary>inventoryID that this item points to, else this item's inventoryID</summary>
+        [IgnoreMember]
         public UUID ActualUUID => IsLink() ? AssetUUID : UUID;
 
         /// <summary>
         ///  Construct a new InventoryItem object
         /// </summary>
         /// <param name="UUID">The <see cref="UUID"/> of the item</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventoryItem(UUID UUID)
             : base(UUID) { }
 
@@ -219,53 +198,6 @@ namespace OpenMetaverse
         public bool IsLink()
         {
             return AssetType == AssetType.Link || AssetType == AssetType.LinkFolder;
-        }
-
-        /// <inheritdoc />
-        /// <summary>
-        /// Get object data
-        /// </summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
-        public override void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            base.GetObjectData(info, context);
-            info.AddValue("AssetUUID", AssetUUID, typeof(UUID));
-            info.AddValue("Permissions", Permissions, typeof(Permissions));
-            info.AddValue("AssetType", AssetType);
-            info.AddValue("InventoryType", InventoryType);
-            info.AddValue("CreatorID", CreatorID);
-            info.AddValue("Description", Description);
-            info.AddValue("GroupID", GroupID);
-            info.AddValue("GroupOwned", GroupOwned);
-            info.AddValue("SalePrice", SalePrice);
-            info.AddValue("SaleType", SaleType);
-            info.AddValue("Flags", Flags);
-            info.AddValue("CreationDate", CreationDate);
-            info.AddValue("LastOwnerID", LastOwnerID);
-        }
-
-        /// <summary>
-        /// Inventory item ctor
-        /// </summary>
-        /// <param name="info"></param>
-        /// <param name="ctxt"></param>
-        public InventoryItem(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
-        {
-            AssetUUID = (UUID)info.GetValue("AssetUUID", typeof(UUID));
-            Permissions = (Permissions)info.GetValue("Permissions", typeof(Permissions));
-            AssetType = (AssetType)info.GetValue("AssetType", typeof(AssetType));
-            InventoryType = (InventoryType)info.GetValue("InventoryType", typeof(InventoryType));
-            CreatorID = (UUID)info.GetValue("CreatorID", typeof(UUID));
-            Description = (string)info.GetValue("Description", typeof(string));
-            GroupID = (UUID)info.GetValue("GroupID", typeof(UUID));
-            GroupOwned = (bool)info.GetValue("GroupOwned", typeof(bool));
-            SalePrice = (int)info.GetValue("SalePrice", typeof(int));
-            SaleType = (SaleType)info.GetValue("SaleType", typeof(SaleType));
-            Flags = (uint)info.GetValue("Flags", typeof(uint));
-            CreationDate = (DateTime)info.GetValue("CreationDate", typeof(DateTime));
-            LastOwnerID = (UUID)info.GetValue("LastOwnerID", typeof(UUID));
         }
 
         /// <summary>
@@ -508,10 +440,7 @@ namespace OpenMetaverse
     /// InventoryTexture Class representing a graphical image
     /// </summary>
     /// <seealso cref="T:OpenMetaverse.Imaging.ManagedImage" />
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventoryTexture : InventoryItem
     {
         /// <summary>
@@ -519,20 +448,8 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="UUID"/> which becomes the 
         /// <seealso cref="InventoryItem"/> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventoryTexture(UUID UUID)
             : base(UUID)
-        {
-            InventoryType = InventoryType.Texture;
-        }
-
-        /// <summary>
-        /// Construct an InventoryTexture object from a serialization stream
-        /// </summary>
-        public InventoryTexture(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
         {
             InventoryType = InventoryType.Texture;
         }
@@ -542,10 +459,7 @@ namespace OpenMetaverse
     /// <summary>
     /// InventorySound Class representing a playable sound
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventorySound : InventoryItem
     {
         /// <summary>
@@ -553,20 +467,8 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="UUID"/> which becomes the 
         /// <seealso cref="InventoryItem"/> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventorySound(UUID UUID)
             : base(UUID)
-        {
-            InventoryType = InventoryType.Sound;
-        }
-
-        /// <summary>
-        /// Construct an InventorySound object from a serialization stream
-        /// </summary>
-        public InventorySound(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
         {
             InventoryType = InventoryType.Sound;
         }
@@ -576,10 +478,7 @@ namespace OpenMetaverse
     /// <summary>
     /// InventoryCallingCard Class, contains information on another avatar
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventoryCallingCard : InventoryItem
     {
         /// <summary>
@@ -587,20 +486,8 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="UUID"/> which becomes the 
         /// <seealso cref="InventoryItem"/> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventoryCallingCard(UUID UUID)
             : base(UUID)
-        {
-            InventoryType = InventoryType.CallingCard;
-        }
-
-        /// <summary>
-        /// Construct an InventoryCallingCard object from a serialization stream
-        /// </summary>
-        public InventoryCallingCard(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
         {
             InventoryType = InventoryType.CallingCard;
         }
@@ -610,10 +497,7 @@ namespace OpenMetaverse
     /// <summary>
     /// InventoryLandmark Class, contains details on a specific location
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventoryLandmark : InventoryItem
     {
         /// <summary>
@@ -621,9 +505,6 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="UUID"/> which becomes the 
         /// <seealso cref="InventoryItem"/> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventoryLandmark(UUID UUID)
             : base(UUID)
         {
@@ -631,18 +512,9 @@ namespace OpenMetaverse
         }
 
         /// <summary>
-        /// Construct an InventoryLandmark object from a serialization stream
-        /// </summary>
-        public InventoryLandmark(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
-        {
-            InventoryType = InventoryType.Landmark;
-
-        }
-
-        /// <summary>
         /// Landmarks use the InventoryItemFlags struct and will have a flag of 1 set if they have been visited
         /// </summary>
+        [IgnoreMember]
         public bool LandmarkVisited
         {
             get => (Flags & 1) != 0;
@@ -658,10 +530,7 @@ namespace OpenMetaverse
     /// <summary>
     /// InventoryObject Class contains details on a primitive or coalesced set of primitives
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventoryObject : InventoryItem
     {
         /// <summary>
@@ -669,9 +538,6 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="UUID"/> which becomes the 
         /// <seealso cref="InventoryItem"/> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventoryObject(UUID UUID)
             : base(UUID)
         {
@@ -679,17 +545,9 @@ namespace OpenMetaverse
         }
 
         /// <summary>
-        /// Construct an InventoryObject object from a serialization stream
-        /// </summary>
-        public InventoryObject(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
-        {
-            InventoryType = InventoryType.Object;
-        }
-
-        /// <summary>
         /// Gets or sets the upper byte of the Flags value
         /// </summary>
+        [IgnoreMember]
         public InventoryItemFlags ItemFlags
         {
             get => (InventoryItemFlags)(Flags & ~0xFF);
@@ -699,6 +557,7 @@ namespace OpenMetaverse
         /// <summary>
         /// Gets or sets the object attachment point, the lower byte of the Flags value
         /// </summary>
+        [IgnoreMember]
         public AttachmentPoint AttachPoint
         {
             get => (AttachmentPoint)(Flags & 0xFF);
@@ -710,10 +569,7 @@ namespace OpenMetaverse
     /// <summary>
     /// InventoryNotecard Class, contains details on an encoded text document
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial  class InventoryNotecard : InventoryItem
     {
         /// <summary>
@@ -721,20 +577,8 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="UUID"/> which becomes the 
         /// <seealso cref="InventoryItem"/> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventoryNotecard(UUID UUID)
             : base(UUID)
-        {
-            InventoryType = InventoryType.Notecard;
-        }
-
-        /// <summary>
-        /// Construct an InventoryNotecard object from a serialization stream
-        /// </summary>
-        public InventoryNotecard(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
         {
             InventoryType = InventoryType.Notecard;
         }
@@ -744,10 +588,7 @@ namespace OpenMetaverse
     /// <summary>
     /// InventoryCategory Class
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventoryCategory : InventoryItem
     {
         /// <summary>
@@ -755,20 +596,8 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="UUID"/> which becomes the 
         /// <seealso cref="InventoryItem"/> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventoryCategory(UUID UUID)
             : base(UUID)
-        {
-            InventoryType = InventoryType.Category;
-        }
-
-        /// <summary>
-        /// Construct an InventoryCategory object from a serialization stream
-        /// </summary>
-        public InventoryCategory(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
         {
             InventoryType = InventoryType.Category;
         }
@@ -778,10 +607,7 @@ namespace OpenMetaverse
     /// <summary>
     /// InventoryLSL Class, represents a Linden Scripting Language object
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventoryLSL : InventoryItem
     {
         /// <summary>
@@ -789,20 +615,8 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="UUID"/> which becomes the 
         /// <seealso cref="InventoryItem"/> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventoryLSL(UUID UUID)
             : base(UUID)
-        {
-            InventoryType = InventoryType.LSL;
-        }
-
-        /// <summary>
-        /// Construct an InventoryLSL object from a serialization stream
-        /// </summary>
-        public InventoryLSL(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
         {
             InventoryType = InventoryType.LSL;
         }
@@ -812,10 +626,7 @@ namespace OpenMetaverse
     /// <summary>
     /// InventorySnapshot Class, an image taken with the viewer
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventorySnapshot : InventoryItem
     {
         /// <inheritdoc />
@@ -824,20 +635,8 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="T:OpenMetaverse.UUID" /> which becomes the 
         /// <seealso cref="T:OpenMetaverse.InventoryItem" /> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventorySnapshot(UUID UUID)
             : base(UUID)
-        {
-            InventoryType = InventoryType.Snapshot;
-        }
-
-        /// <summary>
-        /// Construct an InventorySnapshot object from a serialization stream
-        /// </summary>
-        public InventorySnapshot(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
         {
             InventoryType = InventoryType.Snapshot;
         }
@@ -846,10 +645,7 @@ namespace OpenMetaverse
     /// <summary>
     /// InventoryAttachment Class, contains details on an attachable object
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventoryAttachment : InventoryItem
     {
         /// <summary>
@@ -857,9 +653,6 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="UUID"/> which becomes the 
         /// <seealso cref="InventoryItem"/> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventoryAttachment(UUID UUID)
             : base(UUID)
         {
@@ -867,17 +660,9 @@ namespace OpenMetaverse
         }
 
         /// <summary>
-        /// Construct an InventoryAttachment object from a serialization stream
-        /// </summary>
-        public InventoryAttachment(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
-        {
-            InventoryType = InventoryType.Attachment;
-        }
-
-        /// <summary>
         /// Get the last AttachmentPoint this object was attached to
         /// </summary>
+        [IgnoreMember]
         public AttachmentPoint AttachmentPoint
         {
             get => (AttachmentPoint)Flags;
@@ -889,10 +674,7 @@ namespace OpenMetaverse
     /// <summary>
     /// InventoryWearable Class, details on a clothing item or body part
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventoryWearable : InventoryItem
     {
         /// <summary>
@@ -900,23 +682,12 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="UUID"/> which becomes the 
         /// <seealso cref="InventoryItem"/> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventoryWearable(UUID UUID) : base(UUID) { InventoryType = InventoryType.Wearable; }
-
-        /// <summary>
-        /// Construct an InventoryWearable object from a serialization stream
-        /// </summary>
-        public InventoryWearable(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
-        {
-            InventoryType = InventoryType.Wearable;
-        }
 
         /// <summary>
         /// The <see cref="OpenMetaverse.WearableType"/>, Skin, Shape, Skirt, Etc
         /// </summary>
+        [IgnoreMember]
         public WearableType WearableType
         {
             get => (WearableType)Flags;
@@ -928,10 +699,7 @@ namespace OpenMetaverse
     /// <summary>
     /// InventoryAnimation Class, A bvh encoded object which animates an avatar
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventoryAnimation : InventoryItem
     {
         /// <summary>
@@ -939,20 +707,8 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="UUID"/> which becomes the 
         /// <seealso cref="InventoryItem"/> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventoryAnimation(UUID UUID)
             : base(UUID)
-        {
-            InventoryType = InventoryType.Animation;
-        }
-
-        /// <summary>
-        /// Construct an InventoryAnimation object from a serialization stream
-        /// </summary>
-        public InventoryAnimation(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
         {
             InventoryType = InventoryType.Animation;
         }
@@ -962,10 +718,7 @@ namespace OpenMetaverse
     /// <summary>
     /// InventoryGesture Class, details on a series of animations, sounds, and actions
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventoryGesture : InventoryItem
     {
         /// <summary>
@@ -973,20 +726,8 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="UUID"/> which becomes the 
         /// <seealso cref="InventoryItem"/> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventoryGesture(UUID UUID)
             : base(UUID)
-        {
-            InventoryType = InventoryType.Gesture;
-        }
-
-        /// <summary>
-        /// Construct an InventoryGesture object from a serialization stream
-        /// </summary>
-        public InventoryGesture(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
         {
             InventoryType = InventoryType.Gesture;
         }
@@ -996,10 +737,7 @@ namespace OpenMetaverse
     /// <summary>
     /// InventorySettings, LLSD settings blob as an asset
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventorySettings : InventoryItem
     {
         /// <summary>
@@ -1007,28 +745,17 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="UUID"/> which becomes the 
         /// <seealso cref="InventoryItem"/> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventorySettings(UUID UUID) : base(UUID)
         {
             InventoryType = InventoryType.Settings;
         }
-
-        public InventorySettings(SerializationInfo info, StreamingContext ctxt) : base(info, ctxt)
-        {
-            InventoryType = InventoryType.Settings;
-        }
     }
-    
+
     /// <inheritdoc />
     /// <summary>
     /// InventoryMaterial, material as an asset
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventoryMaterial : InventoryItem
     {
         /// <summary>
@@ -1036,47 +763,38 @@ namespace OpenMetaverse
         /// </summary>
         /// <param name="UUID">A <see cref="UUID"/> which becomes the 
         /// <seealso cref="InventoryItem"/> objects UUID</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventoryMaterial(UUID UUID) : base(UUID)
         {
             InventoryType = InventoryType.Settings;
         }
-
-        public InventoryMaterial(SerializationInfo info, StreamingContext ctxt) : base(info, ctxt)
-        {
-            InventoryType = InventoryType.Settings;
-        }
     }
-    
+
     /// <inheritdoc />
     /// <summary>
     /// A folder contains <see cref="T:OpenMetaverse.InventoryItem" />s and has certain attributes specific 
     /// to itself
     /// </summary>
-    [Serializable]
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
+    [MessagePackObject]
     public partial class InventoryFolder : InventoryBase
     {
         public const int VERSION_UNKNOWN = -1;
 
         /// <summary>The Preferred <see cref="T:OpenMetaverse.FolderType"/> for a folder.</summary>
+        [Key("PreferredType")]
         public FolderType PreferredType;
+
         /// <summary>The Version of this folder</summary>
+        [Key("Version")]
         public int Version;
+
         /// <summary>Number of child items this folder contains.</summary>
+        [Key("DescendentCount")]
         public int DescendentCount;
 
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="UUID">UUID of the folder</param>
-#if NET7_0_OR_GREATER
-        [MemoryPackConstructor]
-#endif
         public InventoryFolder(UUID UUID)
             : base(UUID)
         {
@@ -1092,30 +810,6 @@ namespace OpenMetaverse
         public override string ToString()
         {
             return Name;
-        }
-
-        /// <summary>
-        /// Get Serialization data for this InventoryFolder object
-        /// </summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
-        public override void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            base.GetObjectData(info, context);
-            info.AddValue("PreferredType", PreferredType, typeof(FolderType));
-            info.AddValue("Version", Version);
-            info.AddValue("DescendentCount", DescendentCount);
-        }
-
-        /// <summary>
-        /// Construct an InventoryFolder object from a serialization stream
-        /// </summary>
-        public InventoryFolder(SerializationInfo info, StreamingContext ctxt)
-            : base(info, ctxt)
-        {
-            PreferredType = (FolderType)info.GetValue("PreferredType", typeof(FolderType));
-            Version = (int)info.GetValue("Version", typeof(int));
-            DescendentCount = (int)info.GetValue("DescendentCount", typeof(int));
         }
 
         /// <summary>

--- a/LibreMetaverse/InventoryCache.cs
+++ b/LibreMetaverse/InventoryCache.cs
@@ -1,0 +1,214 @@
+﻿using MessagePack;
+using MessagePack.Formatters;
+using MessagePack.Resolvers;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace OpenMetaverse
+{
+    internal class InventoryCache
+    {
+        private static readonly string InventoryCacheMagic = "INVCACHE";
+        private static readonly int InventoryCacheVersion = 1;
+
+        /// <summary>
+        /// Creates MessagePack serializer options for use in inventory cache serializing and deserializing
+        /// </summary>
+        /// <returns>MessagePack serializer options</returns>
+        private static MessagePackSerializerOptions GetSerializerOptions()
+        {
+            var resolver = MessagePack.Resolvers.CompositeResolver.Create(
+                new List<IMessagePackFormatter>()
+                {
+                    Formatters.UUIDFormatter.Instance,
+                },
+                new List<IFormatterResolver>
+                {
+                    StandardResolver.Instance,
+                }
+            );
+
+            return MessagePackSerializerOptions
+                .Standard
+                .WithResolver(resolver);
+        }
+
+        /// <summary>
+        /// Saves the current inventory structure to a cache file
+        /// </summary>
+        /// <param name="filename">Name of the cache file to save to</param>
+        public static void SaveToDisk(string filename, ConcurrentDictionary<UUID, InventoryNode> Items)
+        {
+            try
+            {
+                using (var bw = new BinaryWriter(File.Open(filename, FileMode.Create)))
+                {
+                    lock (Items)
+                    {
+                        Logger.Log($"Caching {Items.Count} inventory items to {filename}", Helpers.LogLevel.Info);
+
+                        var options = GetSerializerOptions();
+                        var items = Items.Values.ToList();
+
+                        bw.Write(Encoding.ASCII.GetBytes(InventoryCacheMagic));
+                        bw.Write(InventoryCacheVersion);
+                        MessagePackSerializer.Serialize(bw.BaseStream, items, options);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Log("Error saving inventory cache to disk", Helpers.LogLevel.Error, e);
+            }
+        }
+
+        /// <summary>
+        /// Loads in inventory cache file into the inventory structure. Note only valid to call after login has been successful.
+        /// </summary>
+        /// <param name="filename">Name of the cache file to load</param>
+        /// <returns>The number of inventory items successfully reconstructed into the inventory node tree, or -1 on error</returns>
+        public static int RestoreFromDisk(string filename, ConcurrentDictionary<UUID, InventoryNode> Items)
+        {
+            List<InventoryNode> cacheNodes;
+
+            try
+            {
+                if (!File.Exists(filename))
+                {
+                    return -1;
+                }
+
+                using (var br = new BinaryReader(File.Open(filename, FileMode.Open)))
+                {
+                    var options = GetSerializerOptions();
+
+                    if (br.BaseStream.Length < InventoryCacheMagic.Length + sizeof(int))
+                    {
+                        Logger.Log($"Invalid inventory cache file. Missing header.", Helpers.LogLevel.Warning);
+                        return -1;
+                    }
+
+                    var magic = br.ReadBytes(InventoryCacheMagic.Length);
+                    if (Encoding.ASCII.GetString(magic) != InventoryCacheMagic)
+                    {
+                        Logger.Log($"Invalid inventory cache file. Missing magic header.", Helpers.LogLevel.Warning);
+                        return -1;
+                    }
+
+                    var version = br.ReadInt32();
+                    if (version != InventoryCacheVersion)
+                    {
+                        Logger.Log($"Invalid inventory cache file. Expected version {InventoryCacheVersion}, got {version}.", Helpers.LogLevel.Warning);
+                        return -1;
+                    }
+
+                    cacheNodes = MessagePackSerializer.Deserialize<List<InventoryNode>>(br.BaseStream, options);
+                    if (cacheNodes == null)
+                    {
+                        Logger.Log($"Invalid inventory cache file. Failed to deserialize contents.", Helpers.LogLevel.Warning);
+                        return -1;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Log("Error accessing inventory cache file", Helpers.LogLevel.Error, e);
+                return -1;
+            }
+
+            Logger.Log($"Read {cacheNodes.Count} items from inventory cache file", Helpers.LogLevel.Info);
+
+            var dirtyFolders = new HashSet<UUID>();
+
+            // First pass: process InventoryFolders
+            foreach (var cacheNode in cacheNodes)
+            {
+                if (!(cacheNode.Data is InventoryFolder cacheFolder))
+                {
+                    continue;
+                }
+
+                if (cacheNode.Data.ParentUUID == UUID.Zero)
+                {
+                    //We don't need the root nodes "My Inventory" etc as they will already exist for the correct
+                    // user of this cache.
+                    continue;
+                }
+
+                if (!Items.TryGetValue(cacheNode.Data.UUID, out var serverNode))
+                {
+                    // This is an orphaned folder that no longer exists on the server.
+                    continue;
+                }
+
+                if (!(serverNode.Data is InventoryFolder serverFolder))
+                {
+                    Logger.Log($"Cached inventory node folder has a parent that is not an InventoryFolder", Helpers.LogLevel.Warning);
+                    continue;
+                }
+
+                serverNode.NeedsUpdate = cacheFolder.Version != serverFolder.Version;
+
+                if (serverNode.NeedsUpdate)
+                {
+                    Logger.DebugLog($"Inventory Cache/Server version mismatch on {cacheNode.Data.Name} {cacheFolder.Version} vs {serverFolder.Version}");
+                    dirtyFolders.Add(cacheNode.Data.UUID);
+                }
+            }
+
+            // Second pass: process InventoryItems
+            var itemCount = 0;
+            foreach (var cacheNode in cacheNodes)
+            {
+                if (!(cacheNode.Data is InventoryItem cacheItem))
+                {
+                    // Only process InventoryItems
+                    continue;
+                }
+
+                if (!Items.TryGetValue(cacheNode.Data.ParentUUID, out var serverParentNode))
+                {
+                    // This item does not have a parent in our known inventory. The folder was probably deleted on the server
+                    // and our cache is old
+                    continue;
+                }
+
+                if (!(serverParentNode.Data is InventoryFolder serverParentFolder))
+                {
+                    Logger.Log($"Cached inventory node item {cacheItem.Name} has a parent {serverParentNode.Data.Name} that is not an InventoryFolder", Helpers.LogLevel.Warning);
+                    continue;
+                }
+
+                if (dirtyFolders.Contains(serverParentFolder.UUID))
+                {
+                    // This item belongs to a folder that has been marked as dirty, so it too is dirty and must be skipped
+                    continue;
+                }
+
+                if (Items.ContainsKey(cacheItem.UUID))
+                {
+                    // This item was already added to our Items store, likely added from previous server requests during this session
+                    continue;
+                }
+
+                if (!Items.TryAdd(cacheItem.UUID, cacheNode))
+                {
+                    Logger.Log($"Failed to add cache item node {cacheItem.Name} with parent {serverParentFolder.Name}", Helpers.LogLevel.Info);
+                    continue;
+                }
+
+                // Add this cached InventoryItem node to the parent
+                cacheNode.Parent = serverParentNode;
+                serverParentNode.Nodes.Add(cacheItem.UUID, cacheNode);
+                itemCount++;
+            }
+
+            Logger.Log($"Reassembled {itemCount} items from inventory cache file", Helpers.LogLevel.Info);
+            return itemCount;
+        }
+    }
+}

--- a/LibreMetaverse/InventoryNodeDictionary.cs
+++ b/LibreMetaverse/InventoryNodeDictionary.cs
@@ -27,23 +27,15 @@
 
 using System;
 using System.Collections.Generic;
-#if NET7_0_OR_GREATER
-using MemoryPack;
-#endif
 
 namespace OpenMetaverse
 {
-#if NET7_0_OR_GREATER
-    [MemoryPackable]
-#endif
     public partial class InventoryNodeDictionary: IComparer<UUID>
     {
         protected readonly SortedDictionary<UUID, InventoryNode> SDictionary;
         protected readonly Dictionary<UUID, InventoryNode> Dictionary = new Dictionary<UUID, InventoryNode>();
         protected InventoryNode parent;
-#if NET7_0_OR_GREATER
-        [MemoryPackIgnore]
-#endif
+
         protected readonly object syncRoot = new object();
         public int Compare(UUID x, UUID y)
         {
@@ -91,9 +83,6 @@ namespace OpenMetaverse
             set => parent = value;
         }
 
-#if NET7_0_OR_GREATER
-        [MemoryPackIgnore]
-#endif
         public object SyncRoot => syncRoot;
 
         public int Count => Dictionary.Count;

--- a/LibreMetaverse/LibreMetaverse.csproj
+++ b/LibreMetaverse/LibreMetaverse.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="CoreJ2K.Skia" Version="1.1.1.48" />
     <PackageReference Include="log4net" Version="3.0.4" />
-    <PackageReference Include="MemoryPack" Version="1.21.4" />
+    <PackageReference Include="MessagePack" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.4" />
     <PackageReference Include="OggVorbisEncoder" Version="1.2.2" />
     <PackageReference Include="Pfim" Version="0.11.3" />

--- a/LibreMetaverse/LockingDictionary.cs
+++ b/LibreMetaverse/LockingDictionary.cs
@@ -29,7 +29,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 
 namespace OpenMetaverse
 {
@@ -88,13 +87,6 @@ namespace OpenMetaverse
                 Dictionary.Remove(item.Key);
             return true;
 
-        }
-
-        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            lock (Dictionary)
-                Dictionary.GetObjectData(info, context);
         }
 
         public void OnDeserialization(object sender)

--- a/LibreMetaverse/Login.cs
+++ b/LibreMetaverse/Login.cs
@@ -1061,7 +1061,6 @@ namespace OpenMetaverse
 
     #endregion Structs
 
-    [Serializable]
     public class LoginException : Exception
     {
         public LoginException(string message) 

--- a/LibreMetaverse/Messages/LindenMessages.cs
+++ b/LibreMetaverse/Messages/LindenMessages.cs
@@ -603,7 +603,6 @@ namespace OpenMetaverse.Messages.Linden
     /// <summary>
     /// The details of a single parcel in a region, also contains some regionwide globals
     /// </summary>
-    [Serializable]
     public class ParcelPropertiesMessage : IMessage
     {
         /// <summary>Simulator-local ID of this parcel</summary>
@@ -1086,7 +1085,6 @@ namespace OpenMetaverse.Messages.Linden
     }
 
     /// <summary>Base class used for the RemoteParcelRequest message</summary>
-    [Serializable]
     public abstract class RemoteParcelRequestBlock
     {
         public abstract OSDMap Serialize();
@@ -1137,7 +1135,6 @@ namespace OpenMetaverse.Messages.Linden
     /// A message sent from the simulator to the viewer in response to a <see cref="RemoteParcelRequestRequest"/> 
     /// which will contain parcel information
     /// </summary>
-    [Serializable]
     public class RemoteParcelRequestReply : RemoteParcelRequestBlock
     {
         /// <summary>The grid-wide unique parcel ID</summary>
@@ -1170,7 +1167,6 @@ namespace OpenMetaverse.Messages.Linden
     /// A message containing a request for a remote parcel from a viewer, or a response
     /// from the simulator to that request
     /// </summary>
-    [Serializable]
     public class RemoteParcelRequestMessage : IMessage
     {
         /// <summary>The request or response details block</summary>
@@ -4102,13 +4098,11 @@ namespace OpenMetaverse.Messages.Linden
         }
     }
 
-    [Serializable]
     public class DirLandReplyMessage : IMessage
     {
         public UUID AgentID;
         public UUID QueryID;
 
-        [Serializable]
         public class QueryReply
         {
             public int ActualArea;
@@ -4739,7 +4733,6 @@ namespace OpenMetaverse.Messages.Linden
 
 
     /// <summary>Base class used for the ObjectMedia message</summary>
-    [Serializable]
     public abstract class ObjectMediaBlock
     {
         public abstract OSDMap Serialize();
@@ -4941,7 +4934,6 @@ namespace OpenMetaverse.Messages.Linden
     /// <summary>
     /// Message for setting or getting per face MediaEntry
     /// </summary>
-    [Serializable]
     public class ObjectMediaMessage : IMessage
     {
         /// <summary>The request or response details block</summary>
@@ -5489,7 +5481,6 @@ namespace OpenMetaverse.Messages.Linden
     /// <summary>
     /// Message received when requesting AgentProfile for an avatar
     /// </summary>
-    [Serializable]
     public class AgentProfileMessage : IMessage
     {
         public class GroupData

--- a/LibreMetaverse/Permissions.cs
+++ b/LibreMetaverse/Permissions.cs
@@ -24,8 +24,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
+using MessagePack;
 using OpenMetaverse.StructuredData;
+using System;
 
 namespace OpenMetaverse
 {
@@ -61,13 +62,18 @@ namespace OpenMetaverse
         All = 0x1F
     }
 
-    [Serializable]
+    [MessagePackObject]
     public struct Permissions
     {
+        [Key("BaseMask")]
         public PermissionMask BaseMask;
+        [Key("EveryoneMask")]
         public PermissionMask EveryoneMask;
+        [Key("GroupMask")]
         public PermissionMask GroupMask;
+        [Key("NextOwnerMask")]
         public PermissionMask NextOwnerMask;
+        [Key("OwnerMask")]
         public PermissionMask OwnerMask;
 
         public Permissions(uint baseMask, uint everyoneMask, uint groupMask, uint nextOwnerMask, uint ownerMask)

--- a/LibreMetaverse/Rendering/Rendering.cs
+++ b/LibreMetaverse/Rendering/Rendering.cs
@@ -194,7 +194,6 @@ namespace OpenMetaverse.Rendering
 
     #region Exceptions
 
-    [Serializable]
     public class RenderingException : Exception
     {
         public RenderingException(string message)

--- a/LibreMetaverse/TerrainCompressor.cs
+++ b/LibreMetaverse/TerrainCompressor.cs
@@ -29,7 +29,6 @@ using OpenMetaverse.Packets;
 
 namespace OpenMetaverse
 {
-    [Serializable]
     public class TerrainPatch
     {
         #region Enums and Structs

--- a/LibreMetaverse/_Packets_.cs
+++ b/LibreMetaverse/_Packets_.cs
@@ -49,7 +49,6 @@ namespace OpenMetaverse.Packets
     /// <summary>
     /// Thrown when a packet could not be successfully deserialized
     /// </summary>
-    [Serializable]
     public class MalformedDataException : ApplicationException
     {
         /// <summary>


### PR DESCRIPTION
MemoryPack is amazing, but it does not support older .net framework and supporting two different serialization paths is too much. Also BinaryFormatter is too insecure to keep around.

* Replaced MemoryPack and BinaryFormatter with MessagePack, which covers a much wider range of .net frameworks
* Removed all old Serialization tags and methods
* **Potentially Breaking Change**: Removed InventoryNode.ParentID - This was an old serialization hack. Use InventoryNode.Data.ParentUUID instead