### PR TITLE
Fixes for issues that pop up while attempting to debug outfit change issues in radegast

### DIFF
--- a/LibreMetaverse/AppearanceManager.cs
+++ b/LibreMetaverse/AppearanceManager.cs
@@ -618,15 +618,9 @@ namespace OpenMetaverse
                 Logger.Log("Could not retrieve Current Outfit folder", Helpers.LogLevel.Warning, Client);
                 return null;
             }
-            // Fetch from cache...
-            var contents = Client.Inventory.Store.GetContents(cof.UUID);
 
-            // If that fails, fetch from server...
-            if (contents == null || contents.Count == 0)
-            {
-                contents = Client.Inventory.FolderContents(cof.UUID, cof.OwnerID, true, true,
-                    InventorySortOrder.ByDate, TimeSpan.FromMinutes(1), true);
-            }
+            var contents = Client.Inventory.FolderContents(cof.UUID, cof.OwnerID, true, true,
+                InventorySortOrder.ByDate, TimeSpan.FromMinutes(1), true);
 
             var wearables = new MultiValueDictionary<WearableType, WearableData>();
             foreach (var item in contents)

--- a/LibreMetaverse/Inventory.cs
+++ b/LibreMetaverse/Inventory.cs
@@ -225,6 +225,9 @@ namespace OpenMetaverse
         /// <param name="item">The InventoryObject to store</param>
         public void UpdateNodeFor(InventoryBase item)
         {
+            InventoryObjectUpdatedEventArgs itemUpdatedEventArgs = null;
+            InventoryObjectAddedEventArgs itemAddedEventArgs = null;
+
             lock (Items)
             {
                 InventoryNode itemParent = null;
@@ -263,10 +266,9 @@ namespace OpenMetaverse
                     }
 
                     itemNode.Parent = itemParent;
-
                     if (m_InventoryObjectUpdated != null)
                     {
-                        OnInventoryObjectUpdated(new InventoryObjectUpdatedEventArgs(itemNode.Data, item));
+                        itemUpdatedEventArgs = new InventoryObjectUpdatedEventArgs(itemNode.Data, item);
                     }
 
                     itemNode.Data = item;
@@ -277,15 +279,29 @@ namespace OpenMetaverse
                     bool added = Items.TryAdd(item.UUID, itemNode);
                     if (added && m_InventoryObjectAdded != null)
                     {
-                        OnInventoryObjectAdded(new InventoryObjectAddedEventArgs(item));
+                        itemAddedEventArgs = new InventoryObjectAddedEventArgs(item);
                     }
                 }
+            }
+
+            if(itemUpdatedEventArgs != null)
+            {
+                OnInventoryObjectUpdated(itemUpdatedEventArgs);
+            }
+            if(itemAddedEventArgs != null)
+            {
+                OnInventoryObjectAdded(itemAddedEventArgs);
             }
         }
 
         public InventoryNode GetNodeFor(UUID uuid)
         {
             return Items[uuid];
+        }
+
+        public bool TryGetNodeFor(UUID uuid, out InventoryNode value)
+        {
+            return Items.TryGetValue(uuid, out value);
         }
 
         /// <summary>

--- a/LibreMetaverse/Inventory.cs
+++ b/LibreMetaverse/Inventory.cs
@@ -299,9 +299,9 @@ namespace OpenMetaverse
             return Items[uuid];
         }
 
-        public bool TryGetNodeFor(UUID uuid, out InventoryNode value)
+        public bool TryGetNodeFor(UUID uuid, out InventoryNode node)
         {
-            return Items.TryGetValue(uuid, out value);
+            return Items.TryGetValue(uuid, out node);
         }
 
         /// <summary>

--- a/LibreMetaverse/InventoryCache.cs
+++ b/LibreMetaverse/InventoryCache.cs
@@ -47,17 +47,14 @@ namespace OpenMetaverse
             {
                 using (var bw = new BinaryWriter(File.Open(filename, FileMode.Create)))
                 {
-                    lock (Items)
-                    {
-                        Logger.Log($"Caching {Items.Count} inventory items to {filename}", Helpers.LogLevel.Info);
+                    var options = GetSerializerOptions();
+                    var items = Items.Values.ToList();
 
-                        var options = GetSerializerOptions();
-                        var items = Items.Values.ToList();
+                    Logger.Log($"Caching {items.Count} inventory items to {filename}", Helpers.LogLevel.Info);
 
-                        bw.Write(Encoding.ASCII.GetBytes(InventoryCacheMagic));
-                        bw.Write(InventoryCacheVersion);
-                        MessagePackSerializer.Serialize(bw.BaseStream, items, options);
-                    }
+                    bw.Write(Encoding.ASCII.GetBytes(InventoryCacheMagic));
+                    bw.Write(InventoryCacheVersion);
+                    MessagePackSerializer.Serialize(bw.BaseStream, items, options);
                 }
             }
             catch (Exception e)

--- a/LibreMetaverse/InventoryManager.cs
+++ b/LibreMetaverse/InventoryManager.cs
@@ -1326,19 +1326,24 @@ namespace OpenMetaverse
 
         #region Remove
 
-        private void RemoveLocalUi(bool success, UUID folder)
+        private void RemoveLocalUi(bool success, UUID itemId)
         {
-            if (success)
+            if(!success)
             {
-                lock (_Store)
-                {
-                    if (!_Store.Contains(folder)) return;
-                    foreach (var obj in _Store.GetContents(folder))
-                    {
-                        _Store.RemoveNodeFor(obj);
-                    }
-                }
+                return;
             }
+
+            if (!_Store.TryGetNodeFor(itemId, out var item))
+            {
+                return;
+            }
+
+            foreach (var obj in _Store.GetContents(itemId))
+            {
+                RemoveLocalUi(true, obj.UUID);
+            }
+
+            _Store.RemoveNodeFor(item.Data);
         }
 
         /// <summary>


### PR DESCRIPTION
- Add TryGetNodeFor to Inventory
- InventoryManager.RemoveLocalUi now removes the item instead of just its descendants 
- InventoryManager.RemoveLocalUi now recursively removes all descendants of the requested item Inventory.
- UpdateNodeFor no longer holds a lock on Items while calling OnInventoryObjectUpdated and OnInventoryObjectAdded - too many deadlocks with this 
- AppearanceManager.RequestAgentWorn no longer pulls from cache