### PR TITLE
Fix GridManager.CoarseLocationHandler not correctly detecting removed entries

### DIFF
--- a/LibreMetaverse/GridManager.cs
+++ b/LibreMetaverse/GridManager.cs
@@ -905,8 +905,9 @@ namespace OpenMetaverse
             }
 
             // find stale entries (people who left the sim)
-            var removedEntries = coarseEntries.Keys.Where(
-                entry => !e.Simulator.avatarPositions.ContainsKey(entry)).ToList();
+            var removedEntries = e.Simulator.avatarPositions.Keys.Where(
+                avatarId => !coarseEntries.ContainsKey(avatarId))
+                .ToList();
 
             // entry not listed in the previous update
             var newEntries = new List<UUID>();


### PR DESCRIPTION
Logic for removedEntries was recently flipped. This reverts it back to original logic of `removed entities = previously known entities - currently known entities`

https://github.com/cinderblocks/libremetaverse/commit/1a67afb897bdd46bdab633aff3727db38ad1ff53#diff-f236d34b19fa16ce5e27058ec99a64358c531f2b2bc4f7fcbc19b8a6fea998d5L906-L907
