### PR TITLE
Revert recent RequestAgentProfile uri changes 

### DIFF
--- a/LibreMetaverse/AvatarManager.cs
+++ b/LibreMetaverse/AvatarManager.cs
@@ -789,7 +789,8 @@ namespace OpenMetaverse
                 return;
             }
 
-            var uri = new Uri(Client.Network.CurrentSim.Caps.CapabilityURI("AgentProfile"), avatarid.ToString());
+            var baseUri = Client.Network.CurrentSim.Caps.CapabilityURI("AgentProfile");
+            var uri = new Uri($"{baseUri}/{avatarid}");
 
             await Client.HttpCapsClient.GetRequestAsync(uri, cancellationToken, (response, data, error) =>
             {


### PR DESCRIPTION
Revert RequestAgentProfile uri changes from ad5122d878b56e268ba5f6502613e9764023518f - incorrect uri was being generated

```
var baseUri = new Uri("https://localhost/cap/12345678-64c8-d659-7d8a-123456789898");
var avatarId = "08779971-74fa-47ea-af19-5bd3eac311c0";

var uri = new Uri(baseUri, avatarId);
```

results in a uri of `https://localhost/cap/08779971-74fa-47ea-af19-5bd3eac311c0` due to the missing `/` at the end of the capability uri