### PR TITLE
FetchItemHttpAsync now correctly returns null when item not found

### DIFF
--- a/LibreMetaverse/Inventory/InventoryManager.cs
+++ b/LibreMetaverse/Inventory/InventoryManager.cs
@@ -529,7 +529,7 @@ namespace OpenMetaverse
             InventoryItem item = null;
             await RequestFetchInventoryHttpAsync(itemId, ownerId, token, list =>
             {
-                item = list.First();
+                item = list.FirstOrDefault();
             });
             return item;
         }


### PR DESCRIPTION
FetchItemHttpAsync now correctly returns null InventoryItem instead of throwing an exception when item cannot be found