### PR TITLE
Fix a bug in the SplitMultibyteString I added a little bit ago

### DIFF
--- a/LibreMetaverse/AgentManager.cs
+++ b/LibreMetaverse/AgentManager.cs
@@ -1596,6 +1596,13 @@ namespace OpenMetaverse
             {
                 throw new Exception("Split size must be at least 1 byte");
             }
+            if (message.Length == 0)
+            {
+                return new List<string>()
+                {
+                    string.Empty
+                };
+            }
 
             var messageParts = new List<string>();
             var messageBytes = System.Text.Encoding.UTF8.GetBytes(message);


### PR DESCRIPTION
Fix a bug in the SplitMultibyteString I added a little bit ago. Splitting an empty string should result in a list of a single empty string, not an empty list. This is needed for things like accepting group invites since these are sent via empty string messages