### PR TITLE
Fixed GetDisplayNames' capabilities query

### DIFF
--- a/LibreMetaverse/AvatarManager.cs
+++ b/LibreMetaverse/AvatarManager.cs
@@ -722,7 +722,7 @@ namespace OpenMetaverse
 
             var uri = new UriBuilder(Client.Network.CurrentSim.Caps.CapabilityURI("GetDisplayNames"))
             {
-                Query = "ids=" + string.Join("&", ids)
+                Query = "ids=" + string.Join("&ids=", ids)
             };
 
             await Client.HttpCapsClient.GetRequestAsync(uri.Uri, cancellationToken, (response, data, error) =>


### PR DESCRIPTION
It invalidated all ids except the first one and always fetching one display name, despite the number of ids passed to it.