### PR TITLE
Added CreateLinksAsync and AddLinks 

### DIFF
--- a/LibreMetaverse/Appearance/CurrentOutfitFolder.cs
+++ b/LibreMetaverse/Appearance/CurrentOutfitFolder.cs
@@ -520,9 +520,13 @@ namespace LibreMetaverse.Appearance
                 return;
             }
 
+            List<InventoryItem> cofLinks = await GetCurrentOutfitLinks(cancellationToken);
+            IEnumerable<InventoryItem> newLinks = items
+                .Where(item => cofLinks.Find(itemLink => itemLink.AssetUUID == item.ResolvedAssetID) == null);
+
             if (client.AisClient.IsAvailable)
             {
-                await client.Inventory.CreateLinksAsync(COF.UUID, items, success =>
+                await client.Inventory.CreateLinksAsync(COF.UUID, newLinks, success =>
                 {
                     client.Inventory.RequestFolderContents(
                         COF.UUID,
@@ -536,7 +540,7 @@ namespace LibreMetaverse.Appearance
             }
             else
             {
-                foreach (InventoryItem item in items)
+                foreach (InventoryItem item in newLinks)
                 {
                     await AddLink(item, cancellationToken);
                 }

--- a/LibreMetaverse/Appearance/CurrentOutfitFolder.cs
+++ b/LibreMetaverse/Appearance/CurrentOutfitFolder.cs
@@ -1262,10 +1262,7 @@ namespace LibreMetaverse.Appearance
             }
 
             // Add links to new items
-            foreach (var item in itemsToAdd)
-            {
-                await AddLink(item, cancellationToken);
-            }
+            await AddLinks(itemsToAdd, cancellationToken);
 
             client.Appearance.AddToOutfit(itemsToAdd, replace);
             _ = Task.Run(async () =>

--- a/LibreMetaverse/Appearance/CurrentOutfitFolder.cs
+++ b/LibreMetaverse/Appearance/CurrentOutfitFolder.cs
@@ -500,6 +500,49 @@ namespace LibreMetaverse.Appearance
             }
         }
 
+        /// <summary>
+        /// Creates multiple COF links in a single request.
+        /// </summary>
+        /// <param name="items">Original items to be linked to COF</param>
+        /// <remarks>
+        /// Note: On simulators supporting AIS3 it runs in a single request. On simulators not supporting it, it falls back
+        /// to iterating and calling <see cref="AddLink(InventoryItem, CancellationToken)"/> for each element.
+        /// </remarks>
+        public async Task AddLinks(IEnumerable<InventoryItem> items, CancellationToken cancellationToken = default)
+        {
+            if (COF == null)
+            {
+                return;
+            }
+
+            if (items == null || !items.Any())
+            {
+                return;
+            }
+
+            if (client.AisClient.IsAvailable)
+            {
+                await client.Inventory.CreateLinksAsync(COF.UUID, items, success =>
+                {
+                    client.Inventory.RequestFolderContents(
+                        COF.UUID,
+                        COF.OwnerID,
+                        fetchFolders: true,
+                        fetchItems: true,
+                        order: InventorySortOrder.ByName,
+                        cancellationToken: cancellationToken
+                    ).ConfigureAwait(false);
+                }, cancellationToken);
+            }
+            else
+            {
+                foreach (InventoryItem item in items)
+                {
+                    await AddLink(item, cancellationToken);
+                }
+            }
+        }
+
         protected async Task RemoveLinksToByActualId(IEnumerable<UUID> actualItemIdsToRemoveLinksTo, CancellationToken cancellationToken = default)
         {
             var actualItemIdsSet = actualItemIdsToRemoveLinksTo.ToArray();
@@ -736,6 +779,7 @@ namespace LibreMetaverse.Appearance
             }
 
             var trashFolderId = client.Inventory.FindFolderForType(FolderType.Trash);
+            var outfitsFolderId = client.Inventory.FindFolderForType(FolderType.Outfit);
             var rootFolderId = client.Inventory.Store.RootFolder.UUID;
 
             var newOutfit = await client.Inventory.RequestFolderContents(
@@ -965,35 +1009,39 @@ namespace LibreMetaverse.Appearance
             var toRemoveIds = linksToRemove
                 .Select(n => n.UUID)
                 .Distinct();
-            await client.Inventory.RemoveItemsAsync(toRemoveIds, cancellationToken);
+            if (toRemoveIds.Any())
+            {
+                await client.Inventory.RemoveItemsAsync(toRemoveIds, cancellationToken);
+            }
 
             // Add body parts from current outfit to new outfit if it's lacking those essential body parts
             foreach (var item in bodypartsToWear)
             {
                 itemsBeingAdded.Add(item.Value.UUID, item.Value);
             }
-            foreach (var item in itemsBeingAdded)
-            {
-                await AddLink(item.Value, cancellationToken);
-            }
+            await AddLinks(itemsBeingAdded.Values, cancellationToken);
 
-            // Add link to outfit folder we're putting on
-            await client.Inventory.CreateLinkAsync(
-                currentOutfitFolder.UUID,
-                newOutfitFolderNode.Data.UUID,
-                newOutfitFolderNode.Data.Name,
-                "",
-                InventoryType.Folder,
-                UUID.Random(),
-                (success, newItem) =>
-                {
+            bool isOutfitFolder = await IsObjectDescendentOf(newOutfitFolderNode.Data, outfitsFolderId, cancellationToken);
+            // Add link to outfit folder we're putting on, but only if its a child of "Outfits"
+            if (isOutfitFolder)
+            {
+                await client.Inventory.CreateLinkAsync(
+                    currentOutfitFolder.UUID,
+                    newOutfitFolderNode.Data.UUID,
+                    newOutfitFolderNode.Data.Name,
+                    "",
+                    InventoryType.Folder,
+                    UUID.Random(),
+                    (success, newItem) =>
+                    {
                         if (success && newItem != null)
                         {
                             _ = client.Inventory.RequestFetchInventoryAsync(newItem.UUID, newItem.OwnerID);
                         }
-                },
-                cancellationToken
-            ).ConfigureAwait(false);
+                    },
+                    cancellationToken
+                ).ConfigureAwait(false);
+            }
 
             // Wear new outfit
             var tcs = new TaskCompletionSource<bool>();

--- a/LibreMetaverse/Inventory/InventoryManager.cs
+++ b/LibreMetaverse/Inventory/InventoryManager.cs
@@ -1989,6 +1989,73 @@ namespace OpenMetaverse
             }
         }
 
+        /// <summary>
+        /// Creates multiple inventory links to another inventory item or folder atonce
+        /// </summary>
+        /// <param name="folderID"></param>
+        /// <param name="items"></param>
+        /// <param name="callback"></param>
+        public async Task CreateLinksAsync(
+            UUID folderID,
+            IEnumerable<InventoryBase> items,
+            Action<bool> callback,
+            CancellationToken cancellationToken = default
+        )
+        {
+            if (Client.AisClient.IsAvailable)
+            {
+                OSDArray links = new OSDArray();
+                foreach (InventoryBase baseItem in items)
+                {
+                    switch (baseItem)
+                    {
+                        case InventoryItem item:
+                            {
+                                OSDMap link = new OSDMap
+                                {
+                                    ["linked_id"] = OSD.FromUUID(item.UUID),
+                                    ["type"] = OSD.FromInteger((int)AssetType.Link),
+                                    ["inv_type"] = OSD.FromInteger((int)item.InventoryType),
+                                    ["name"] = OSD.FromString(item.Name),
+                                    ["desc"] = OSD.FromString(item.Description)
+                                };
+
+                                links.Add(link);
+                                break;
+                            }
+                        case InventoryFolder folder:
+                            {
+                                OSDMap link = new OSDMap
+                                {
+                                    ["linked_id"] = OSD.FromUUID(folder.UUID),
+                                    ["type"] = OSD.FromInteger((int)AssetType.LinkFolder),
+                                    ["inv_type"] = OSD.FromInteger((int)InventoryType.Folder),
+                                    ["name"] = OSD.FromString(folder.Name),
+                                    ["desc"] = OSD.FromString(string.Empty)
+                                };
+
+                                links.Add(link);
+                            }
+                            break;
+                    }
+                }
+
+                OSDMap newInventory = new OSDMap { { "links", links } };
+
+                await Client.AisClient.CreateInventory(
+                    folderID,
+                    newInventory,
+                    true,
+                    (success, reply) => callback?.Invoke(success),
+                    cancellationToken
+                ).ConfigureAwait(false);
+            }
+            else
+            {
+                throw new InvalidOperationException("Creating of batch links only supported on AIS3");
+            }
+        }
+
         #endregion Create
 
         #region Copy

--- a/LibreMetaverse/Inventory/InventoryManager.cs
+++ b/LibreMetaverse/Inventory/InventoryManager.cs
@@ -1990,7 +1990,7 @@ namespace OpenMetaverse
         }
 
         /// <summary>
-        /// Creates multiple inventory links to another inventory item or folder atonce
+        /// Creates multiple inventory links to another inventory item or folder at once.
         /// </summary>
         /// <param name="folderID"></param>
         /// <param name="items"></param>


### PR DESCRIPTION
Added CreateLinksAsync and AddLinks which allows to create multiple Links in a single request when AIS3 is supported which drastically reduces the competition time when adding 5+ links, i.e. for adding/replacing outfits

Fixes a minor bug in ReplaceOutfit that will create a folder link for folders that are not in children of "Outfits", where its not desired to do a folder link (folder Links are only used as indicator for the currently active appearance in SL Viewers Appearance tab).

In my tests even moderately sized outfits of 17 items took 5-10 seconds until the outfit was fully work which did drive me insane. 

With the batched AddLinks AIS3 Request, the outfit switchs and appears fully in-world (assuming work items existed in the Viewers Cache already) is less than 1 second now. It falls back to one request per link if AIS3 isn't supported. Dunno if the old API has similar batching capabilities.