### PR TITLE
Bugfix for broken RequestUpdateScript*() functions

### DIFF
--- a/LibreMetaverse/Inventory/InventoryManager.Async.cs
+++ b/LibreMetaverse/Inventory/InventoryManager.Async.cs
@@ -269,7 +269,7 @@ namespace OpenMetaverse
 
             try
             {
-                var result = await PostStringAsync(cap, request.Serialize(), cancellationToken, progress).ConfigureAwait(false);
+                var result = await PostCapAsync(cap, request.Serialize(), cancellationToken, progress).ConfigureAwait(false);
                 UpdateScriptAgentInventoryResponse(new KeyValuePair<ScriptUpdatedCallback, byte[]>(callback, data),
                     itemID, result, null, cancellationToken, progress);
             }
@@ -297,7 +297,7 @@ namespace OpenMetaverse
 
             try
             {
-                var result = await PostStringAsync(cap, msg.Serialize(), cancellationToken, progress).ConfigureAwait(false);
+                var result = await PostCapAsync(cap, msg.Serialize(), cancellationToken, progress).ConfigureAwait(false);
                 UpdateScriptAgentInventoryResponse(new KeyValuePair<ScriptUpdatedCallback, byte[]>(callback, data),
                     itemID, result, null, cancellationToken, progress);
             }


### PR DESCRIPTION
## Description
When trying to use the `RequestUpdateScript*Async()` functions, the `uploadStatus` response would always be "Failed to parse capability response: Unable to deserialize data: unrecognized format." The issue is that `PostStringAsync(cap, msg.Serialize(), ...)` takes a string as its second parameter, but `msg.Serialize()` returns an `OSDMap`. `OSDMap` inherits from `OSD` which has public static implicit operator `string(OSD value) { return value.AsString(); }`, and `OSDMap.AsString()` falls back to the base implementation returning `string.Empty`, so an empty string is getting sent as the message.

The fix is to use `PostCapAsync` instead of `PostStringAsync`. It takes an OSD directly and serializes it properly as XML LLSD before posting.

## Changes
- Replaced calls to `PostStringAsync` with `PostCapAsync` in `RequestUpdateScriptAgentInventoryAsync` and `RequestUpdateScriptTaskAsync`

## Testing
`dotnet build` project built successfully
`dotnet test` all tests passing


