### PR TITLE
Bugfix for broken SimConsoleAsync message

### DIFF
--- a/LibreMetaverse/EstateTools.cs
+++ b/LibreMetaverse/EstateTools.cs
@@ -1279,10 +1279,9 @@ namespace OpenMetaverse
                 return null;
             }
 
-            var msg = new SimConsoleAsyncMessage { Command = command };
             string? output = null;
 
-            await Client.HttpCapsClient.PostRequestAsync(cap, OSDFormat.Xml, msg.Serialize(), cancellationToken,
+            await Client.HttpCapsClient.PostRequestAsync(cap, OSDFormat.Xml, OSD.FromString(command), cancellationToken,
                 (response, data, error) =>
                 {
                     if (error != null)
@@ -1294,11 +1293,7 @@ namespace OpenMetaverse
                     try
                     {
                         if (OSDParser.Deserialize(data) is OSDMap map)
-                        {
-                            var reply = new SimConsoleAsyncMessage();
-                            reply.Deserialize(map);
-                            output = reply.Output;
-                        }
+                            output = map["Response"].AsString();
                     }
                     catch (Exception ex)
                     {

--- a/LibreMetaverse/EstateTools.cs
+++ b/LibreMetaverse/EstateTools.cs
@@ -1279,9 +1279,10 @@ namespace OpenMetaverse
                 return null;
             }
 
+            var msg = new SimConsoleAsyncMessage { Command = command };
             string? output = null;
 
-            await Client.HttpCapsClient.PostRequestAsync(cap, OSDFormat.Xml, OSD.FromString(command), cancellationToken,
+            await Client.HttpCapsClient.PostRequestAsync(cap, OSDFormat.Xml, msg.Serialize(), cancellationToken,
                 (response, data, error) =>
                 {
                     if (error != null)
@@ -1293,7 +1294,11 @@ namespace OpenMetaverse
                     try
                     {
                         if (OSDParser.Deserialize(data) is OSDMap map)
-                            output = map["Response"].AsString();
+                        {
+                            var reply = new SimConsoleAsyncMessage();
+                            reply.Deserialize(map);
+                            output = reply.Output;
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/LibreMetaverse/Messages/LindenMessages.cs
+++ b/LibreMetaverse/Messages/LindenMessages.cs
@@ -6773,7 +6773,7 @@ namespace OpenMetaverse.Messages.Linden
     /// Available only to estate owners/managers and Linden Lab staff (god mode).
     /// Corresponds to LLSimConsole in the SL C++ viewer (llsimconsole.cpp).
     /// </summary>
-    public class SimConsoleAsyncMessage : IMessage
+    public class SimConsoleAsyncMessage
     {
         /// <summary>The console command to execute on the simulator</summary>
         public string Command = string.Empty;
@@ -6784,17 +6784,17 @@ namespace OpenMetaverse.Messages.Linden
         /// </summary>
         public string Output = string.Empty;
 
-        /// <inheritdoc/>
-        public OSDMap Serialize()
+        /// <summary>Serializes the command as a plain LLSD string (the wire format expected by the simulator).</summary>
+        public OSD Serialize()
         {
-            return new OSDMap(1) { ["console"] = OSD.FromString(Command) };
+            return OSD.FromString(Command);
         }
 
-        /// <inheritdoc/>
-        public void Deserialize(OSDMap map)
+        /// <summary>Deserializes an LLSD response from the simulator.</summary>
+        public void Deserialize(OSD osd)
         {
-            Command = map.ContainsKey("console") ? map["console"].AsString() : string.Empty;
-            Output  = map.ContainsKey("output")  ? map["output"].AsString()  : string.Empty;
+            if (osd is OSDMap map)
+                Output = map["Response"].AsString();
         }
     }
 


### PR DESCRIPTION
### Description
When trying to use `SendSimConsoleCommandAsync()` the command would not get executed on the simulator, and the response would be an "unknown error". The issue is that the `SimConsoleAsyncMessage` `Serialize` and `Deserialize` methods are assuming the wrong data. Currently, `Serialize` expects an `OSDMap` with a key of `console`, while `Deserialize` is expecting an `OSDMap` with keys of `console` and `output`. Here is an example of what the server actually expects:
Request:
```
# https://simhost-0f95d1f4c0da07fb8.aditi.secondlife.io:12043/cap/aaa0a069-5635-2812-23a2-d92a8cdb0523
Host: simhost-0f95d1f4c0da07fb8.aditi.secondlife.io:12043
Accept-Encoding: deflate, gzip
Connection: keep-alive
Keep-alive: 300
Accept: application/llsd+xml
Content-Type: application/llsd+xml
X-SecondLife-UDP-Listen-Port: 64404
Content-Length: 35

<?xml version="1.0" ?>
<llsd>
<string>help</string>
</llsd>
```
Response:
```
HTTP/1.1 200 OK
Date: Wed, 10 Jun 2026 22:46:31 GMT
Server: Apache
X-LL-Request-Id: ainpR5X3HaB8Z6YaKD3ojgAAASQ
Content-Length: 1088
Content-Type: application/llsd+xml
Access-Control-Allow-Origin: *
Keep-Alive: timeout=10, max=95
Connection: Keep-Alive

<?xml version="1.0" ?>
<llsd>
<map>
   <key>Agent</key>
    <uuid>fea2598e-b618-4748-bb9c-1cfad0ecd51b</uuid>
   <key>Command</key>
    <string>help</string>
   <key>Response</key>
    <string>Help is available for the following commands and topics. Type "help &lt;topic&gt;" for more information.
Note that all commands are case insensitive.
    region_schedule     Display or modify scheduled region events.
    estate_environment  Set the default environment for the entire estate.
    update-pathfinding-objects Batch updates specified objects to the requested linkset use. See help for more info.
    Get                 Retrieve the value of a parameter.
    Set                 Set the value of a parameter.
    Unset               Returns a parameter to its built-in default. (Only available for certain parameters.)
    Parameters          List parameters you are authorized to view or modify.
    Restart             Restart the region after a specified amount of time (default 5 minutes).
</string>
   <key>grid</key>
    <string>aditi</string>
   <key>region_id</key>
    <uuid>b4eb5dbb-c290-4631-9115-f879d5399c61</uuid>
  </map>
</llsd>
```

### Changes
I update `SimConsoleAsyncMessage` to serialize and deserialize in the format expected by the simulator. The only hiccup here is that I also had to remove the `IMessage` interface because it wants `Serialize` to return an `OSDMap`, but in this case the format expected by the simulator is not a map, just a plain `OSD`. Please let me know if you'd like to handle this a different way.

### Testing
`dotnet build` project built successfully
`dotnet test` all tests passing
I also made sure that I could successfully execute region console commands and recieve an appropriate response using `SendSimConsoleCommandAsync`