### PR TITLE
Bug fix: Change the default transaction ID for UpdateTaskInventory to UUID Zero instead of Random

### DIFF
--- a/LibreMetaverse/Inventory/InventoryManager.Task.cs
+++ b/LibreMetaverse/Inventory/InventoryManager.Task.cs
@@ -40,6 +40,7 @@ namespace OpenMetaverse
         /// <param name="objectLocalID">The target object</param>
         /// <param name="item">The item to copy or move from inventory</param>
         /// <param name="simulator">Simulator containing the target object, or null for the current simulator</param>
+        /// <param name="only_mod_meta">If flase, the transaction ID will set be set to a random UUID, and the simulator will re-create the item, potentially breaking things like scripts.</param>
         /// <returns>Returns transaction id</returns>
         /// <remarks>For items with copy permissions a copy of the item is placed in the tasks inventory,
         /// for no-copy items the object is moved to the tasks inventory</remarks>

--- a/LibreMetaverse/Inventory/InventoryManager.Task.cs
+++ b/LibreMetaverse/Inventory/InventoryManager.Task.cs
@@ -43,9 +43,9 @@ namespace OpenMetaverse
         /// <returns>Returns transaction id</returns>
         /// <remarks>For items with copy permissions a copy of the item is placed in the tasks inventory,
         /// for no-copy items the object is moved to the tasks inventory</remarks>
-        public UUID UpdateTaskInventory(uint objectLocalID, InventoryItem item, Simulator? simulator = null)
+        public UUID UpdateTaskInventory(uint objectLocalID, InventoryItem item, Simulator? simulator = null, bool only_mod_meta = true)
         {
-            var transactionID = UUID.Random();
+            var transactionID = only_mod_meta ? UUID.Zero : UUID.Random();
 
             var update = new UpdateTaskInventoryPacket
             {


### PR DESCRIPTION
### Issue
If you send a random transaction ID with an UpdateTaskInventory request, the simulator will create a new item instead of just updating the existing item. I found this when I was trying to rename a script in an object's inventory. When sending a random UUID, the script would get renamed, but the associated text and bytecode would get lost. 

### Solution
Change UpdateTaskInventory to default to sending a zero UUID, with an optional argument to send a random UUID for the cases where it might still be needed. For most cases where only the inventory item's metadata is getting updated, you'd want to default to a zero UUID.

### Testing:
- All tests passed
- Renaming a script in an object with UpdateTaskInventory() does no longer causes the script to lose it's text and bytecode.