### PR TITLE
Fix OSD to InventoryItem parsing

### DIFF
--- a/LibreMetaverse.Tests/InventoryAISClientTests.cs
+++ b/LibreMetaverse.Tests/InventoryAISClientTests.cs
@@ -8,12 +8,13 @@ namespace LibreMetaverse.Tests
     [TestFixture]
     public class InventoryAISClientTests
     {
-        private static OSDMap MakePermissions(UUID creator, UUID lastOwner)
+        private static OSDMap MakePermissions(UUID creator, UUID lastOwner, UUID? owner = null)
         {
             return new OSDMap
             {
                 { "creator_id", OSD.FromUUID(creator) },
                 { "last_owner_id", OSD.FromUUID(lastOwner) },
+                { "owner_id", OSD.FromUUID(owner ?? lastOwner) },
                 { "base_mask", 0 },
                 { "everyone_mask", 0 },
                 { "group_mask", 0 },
@@ -98,7 +99,7 @@ namespace LibreMetaverse.Tests
                 { "inv_type", (int)InventoryType.Object },
                 { "type", (int)AssetType.Object },
                 { "created_at", createdAt },
-                { "permissions", MakePermissions(UUID.Random(), UUID.Random()) },
+                { "permissions", MakePermissions(UUID.Random(), UUID.Random(), agentId) },
                 { "sale_info", MakeSaleInfo() }
             };
 

--- a/LibreMetaverse/Inventory/InventoryBase.cs
+++ b/LibreMetaverse/Inventory/InventoryBase.cs
@@ -260,7 +260,47 @@ namespace LibreMetaverse
         /// <returns>Inventory item created</returns>
         public static InventoryItem FromOSD(OSD data)
         {
+            /*  OSD map looks like (from e.g. GetTaskInventoryAsync()):
+            {
+                "asset_id": "00000000-0000-0000-0000-000000000000",
+                "created_at": 1785363605,
+                "desc": "description",
+                "flags": 0,
+                "inv_type": "script",
+                "item_id": "806baac6-64cd-daae-efff-627208ed1d2b",
+                "metadata": {
+                },
+                "name": "New Script",
+                "parent_id": "74a61033-366a-0b89-4d4b-649c5b0de2ad",
+                "permissions": {
+                    "base_mask": 2147483647,
+                    "creator_id": "90d514eb-85f5-4ffe-b95e-20bcc77168db",
+                    "everyone_mask": 0,
+                    "group_id": "00000000-0000-0000-0000-000000000000",
+                    "group_mask": 0,
+                    "is_owner_group": false,
+                    "last_owner_id": "90d514eb-85f5-4ffe-b95e-20bcc77168db",
+                    "next_owner_mask": 532480,
+                    "owner_id": "90d514eb-85f5-4ffe-b95e-20bcc77168db",
+                    "owner_mask": 2147483647
+                },
+                "sale_info": {
+                    "sale_price": 10,
+                    "sale_type": "not"
+                },
+                "type": "lsltext"
+            }
+            */
             OSDMap descItem = (OSDMap)data;
+
+            InventoryType invType = descItem["inv_type"].Type == OSDType.String
+                ? Utils.StringToInventoryType(descItem["inv_type"].AsString())
+                : (InventoryType)descItem["inv_type"].AsInteger();
+
+            AssetType assetType = descItem["type"].Type == OSDType.String
+                ? Utils.StringToAssetType(descItem["type"].AsString())
+                : (AssetType)descItem["type"].AsInteger();
+
             /*
              * Objects that have been attached in-world prior to being stored on the
              * asset server are stored with the InventoryType of 0 (Texture)
@@ -269,25 +309,24 @@ namespace LibreMetaverse
              * This corrects that behavior by forcing Object Asset types that have an
              * invalid InventoryType with the proper InventoryType of Attachment.
              */
-            InventoryType type = (InventoryType)descItem["inv_type"].AsInteger();
-            if (type == InventoryType.Texture &&
-                ((AssetType)descItem["type"].AsInteger() == AssetType.Object
-                 || (AssetType)descItem["type"].AsInteger() == AssetType.Mesh))
+            if (invType == InventoryType.Texture &&
+                (assetType == AssetType.Object || assetType == AssetType.Mesh))
             {
-                type = InventoryType.Attachment;
+                invType = InventoryType.Attachment;
             }
-            InventoryItem item = InventoryManager.CreateInventoryItem(type, descItem["item_id"]);
+
+            InventoryItem item = InventoryManager.CreateInventoryItem(invType, descItem["item_id"]);
 
             item.ParentUUID = descItem["parent_id"];
             item.Name = descItem["name"];
             item.Description = descItem["desc"];
-            item.OwnerID = descItem["agent_id"];
             item.AssetUUID = descItem["asset_id"];
-            item.AssetType = (AssetType)descItem["type"].AsInteger();
+            item.AssetType = assetType;
             item.CreationDate = Utils.UnixTimeToDateTime(descItem["created_at"]);
             item.Flags = descItem["flags"];
 
             OSDMap perms = (OSDMap)descItem["permissions"];
+            item.OwnerID = perms["owner_id"];
             item.CreatorID = perms["creator_id"];
             item.LastOwnerID = perms["last_owner_id"];
             item.Permissions = new Permissions(perms["base_mask"], perms["everyone_mask"], perms["group_mask"], perms["next_owner_mask"], perms["owner_mask"]);


### PR DESCRIPTION
### Issue:
I noticed that my call to `UpdateTaskInventory()` was no longer updating the item in an object's inventory. I am finding the `InventoryItem` with `GetTaskInventoryAsync()`, modifying it and then passing it back to `UpdateTaskInventory()`. 

The issue is that `GetTaskInventoryAsync()` was changed to first try and use `GetTaskInventoryViaCapAsync()`, which relies on `InventoryItem FromOSD()` to parse the deserialized llsd from the `RequestTaskInventory` cap. `InventoryItem FromOSD()` is incorrectly parsing the OSDMap that is created in `GetTaskInventoryViaCapAsync()`:
- `ownerID` is not getting parsed at all
- `invType` and `assetType` are being read as ints, but are strings in the OSDMap

So the wrong item data is getting sent to the simulator though `UpdateTaskInventory()`, and the simulator cannot update the item.

### Verifications
- project builds
- all tests passing
- `GetTaskInventoryAsync()` provides a correct `InventoryItem` list.