### PR TITLE
Fix InventoryType wire values

### DIFF
--- a/LibreMetaverse.Tests/InventoryManagerTests.cs
+++ b/LibreMetaverse.Tests/InventoryManagerTests.cs
@@ -90,5 +90,31 @@ namespace LibreMetaverse.Tests
                 Assert.That(unknown, Is.InstanceOf<InventoryItem>());
             }
         }
+
+        [TestCase(23, "Widget", "widget")]
+        [TestCase(24, "Person", "person")]
+        [TestCase(25, "Settings", "settings")]
+        [TestCase(26, "Material", "material")]
+        [TestCase(27, "GLTF", "gltf")]
+        [TestCase(28, "GLTFBin", "glbin")]
+        public void InventoryTypeCanonicalTail_HasExpectedWireValueAndName(int value, string enumName, string wireName)
+        {
+            var inventoryType = (InventoryType)value;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(Enum.GetName(typeof(InventoryType), inventoryType), Is.EqualTo(enumName));
+                Assert.That(Utils.InventoryTypeToString(inventoryType), Is.EqualTo(wireName));
+                Assert.That(Utils.StringToInventoryType(wireName), Is.EqualTo(inventoryType));
+            }
+        }
+
+        [Test]
+        public void CreateInventoryItem_MaterialWireValue_ReturnsMaterial()
+        {
+            var item = InventoryManager.CreateInventoryItem((InventoryType)26, UUID.Random());
+
+            Assert.That(item, Is.InstanceOf<InventoryMaterial>());
+        }
     }
 }

--- a/LibreMetaverse.Types/Enums.cs
+++ b/LibreMetaverse.Types/Enums.cs
@@ -297,10 +297,18 @@ namespace LibreMetaverse
         Gesture = 20,
         /// <summary></summary>
         Mesh = 22,
-        /// <summary></summary>
-        Settings = 23,
-        /// <summary></summary>
-        Material = 24,
+        /// <summary>Widget</summary>
+        Widget = 23,
+        /// <summary>Person</summary>
+        Person = 24,
+        /// <summary>Settings</summary>
+        Settings = 25,
+        /// <summary>Render material</summary>
+        Material = 26,
+        /// <summary>glTF asset</summary>
+        GLTF = 27,
+        /// <summary>Binary glTF asset</summary>
+        GLTFBin = 28,
     }
 
     /// <summary>

--- a/LibreMetaverse.Types/UtilsConversions.cs
+++ b/LibreMetaverse.Types/UtilsConversions.cs
@@ -171,7 +171,13 @@ namespace LibreMetaverse
 	        "animation",  // 19
 	        "gesture",    // 20
             string.Empty, // 21
-            "mesh"        // 22
+            "mesh",       // 22
+            "widget",     // 23
+            "person",     // 24
+            "settings",   // 25
+            "material",   // 26
+            "gltf",       // 27
+            "glbin"       // 28
         };
 
         private static readonly string[] _SaleTypeNames = {


### PR DESCRIPTION
## Description

Align the public `InventoryType` tail with the current Second Life wire values and extend the existing type-name table through GLTF binary assets.

The corrected assignments are:

- `Widget = 23`
- `Person = 24`
- `Settings = 25`
- `Material = 26`
- `GLTF = 27`
- `GLTFBin = 28`

This intentionally corrects the existing public numeric values for `Settings` (`23` to `25`) and `Material` (`24` to `26`). Consumers compiled against the old constants should rebuild against the corrected enum.

The values and wire names are based on the authoritative Second Life Viewer definitions in [`llinventorytype.h`](https://github.com/secondlife/viewer/blob/develop/indra/llinventory/llinventorytype.h) and [`llinventorytype.cpp`](https://github.com/secondlife/viewer/blob/develop/indra/llinventory/llinventorytype.cpp).

## Testing

- Added deterministic coverage for numeric values, enum names, and string round trips for values 23–28.
- Added a regression test proving incoming wire value 26 creates `InventoryMaterial`.
- Focused regression: 7/7 passed after the fix; the same cases failed before it.
- Neighboring `InventoryManagerTests`: 10/10 passed.
- `LibreMetaverse.Types` net10.0 Release build: succeeded with no warnings or errors.

The broader net10.0 test run is not completely green: 7 existing `HttpListener`-based tests fail on this Windows environment with error code 6. The identical seven failures reproduce on the untouched base revision, while the candidate adds seven passing tests, so those failures are unrelated to this change.

No live Agni validation was performed.

Fixes #170
