### PR TITLE
Honor texture benefit upload cost

### DIFF
--- a/LibreMetaverse.Tests/InventoryManagerTests.cs
+++ b/LibreMetaverse.Tests/InventoryManagerTests.cs
@@ -26,6 +26,8 @@
 
 using NUnit.Framework;
 using System;
+using System.Collections;
+using System.Reflection;
 
 namespace LibreMetaverse.Tests
 {
@@ -115,6 +117,53 @@ namespace LibreMetaverse.Tests
             var item = InventoryManager.CreateInventoryItem((InventoryType)26, UUID.Random());
 
             Assert.That(item, Is.InstanceOf<InventoryMaterial>());
+        }
+
+        [TestCase(25, 10, 25)]
+        [TestCase(0, 10, 0)]
+        [TestCase(null, 10, 10)]
+        public void GetUploadCostForAssetType_TextureUsesPresentBenefitOrBaseFallback(
+            int? textureUploadCost, int baseUploadCost, int expected)
+        {
+            var actual = GetUploadCostForAssetType(
+                AssetType.Texture, "texture_upload_cost", textureUploadCost, baseUploadCost);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [TestCase(AssetType.Animation, "animation_upload_cost", 7, 7)]
+        [TestCase(AssetType.Animation, "animation_upload_cost", null, 10)]
+        [TestCase(AssetType.Sound, "sound_upload_cost", 8, 8)]
+        [TestCase(AssetType.Sound, "sound_upload_cost", null, 10)]
+        [TestCase(AssetType.Object, "mesh_upload_cost", 9, 9)]
+        [TestCase(AssetType.Object, "mesh_upload_cost", null, 10)]
+        public void GetUploadCostForAssetType_PreservesNeighboringBenefitAndFallbackBehavior(
+            AssetType assetType, string benefitKey, int? benefitCost, int expected)
+        {
+            var actual = GetUploadCostForAssetType(assetType, benefitKey, benefitCost, 10);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        private static int GetUploadCostForAssetType(
+            AssetType assetType, string benefitKey, int? benefitCost, int baseUploadCost)
+        {
+            var client = new GridClient();
+            client.Settings.UploadCost = baseUploadCost;
+
+            var values = new Hashtable();
+            if (benefitCost.HasValue)
+                values[benefitKey] = benefitCost.Value;
+
+            var benefitsProperty = typeof(AgentManager).GetProperty(nameof(AgentManager.Benefits));
+            Assert.That(benefitsProperty, Is.Not.Null);
+            benefitsProperty!.SetValue(client.Self, new AccountLevelBenefits(values));
+
+            var method = typeof(InventoryManager).GetMethod(
+                "GetUploadCostForAssetType", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(method, Is.Not.Null);
+
+            return (int)method!.Invoke(client.Inventory, new object[] { assetType })!;
         }
     }
 }

--- a/LibreMetaverse/Inventory/InventoryManager.cs
+++ b/LibreMetaverse/Inventory/InventoryManager.cs
@@ -2169,13 +2169,16 @@ namespace LibreMetaverse
         /// <summary>
         /// Returns the correct <c>expected_upload_cost</c> in L$ for the given asset type,
         /// using account-level benefit costs where available and falling back to
-        /// <see cref="Settings.UploadCost"/> (the texture cost) for types not separately priced.
+        /// <see cref="Settings.UploadCost"/> when a specific cost is unavailable.
         /// </summary>
         private int GetUploadCostForAssetType(AssetType assetType)
         {
             var b = Client.Self.Benefits;
             return assetType switch
             {
+                AssetType.Texture => b.TextureUploadCost >= 0
+                    ? b.TextureUploadCost
+                    : Client.Settings.UploadCost,
                 AssetType.Animation => b.AnimationUploadCost > 0 ? b.AnimationUploadCost : Client.Settings.UploadCost,
                 AssetType.Sound     => b.SoundUploadCost     > 0 ? b.SoundUploadCost     : Client.Settings.UploadCost,
                 AssetType.Object    => b.MeshUploadCost      > 0 ? b.MeshUploadCost      : Client.Settings.UploadCost,
@@ -2184,4 +2187,3 @@ namespace LibreMetaverse
         }
     }
 }
-


### PR DESCRIPTION
## Description

- Use the account's `TextureUploadCost` benefit for texture inventory uploads when that benefit is present.
- Preserve `0` as a valid free-upload price.
- Fall back to `Settings.UploadCost` only when `TextureUploadCost` is absent (`-1`).
- Add focused coverage for positive, zero, and absent texture costs while preserving neighboring upload-cost behavior.

## Motivation

`GetUploadCostForAssetType` already considered account benefits for animation, sound, and object uploads, but texture uploads fell through to the base upload cost. `AccountLevelBenefits` uses `-1` as the absent sentinel, so a present value of `0` must not be treated as missing.

## Testing

- Focused regression: 7/9 passed before the fix (the positive and zero texture cases failed), then 9/9 passed after the fix.
- Complete `InventoryManagerTests` fixture: 19/19 passed after the refreshed candidate validation.
- Affected `LibreMetaverse` net10.0 Release build: 0 warnings and 0 errors.
- Broader net10.0 refreshed candidate run: 1,204 passed, 19 skipped, and 7 failed. The same seven `HttpListener` ErrorCode 6 failures reproduced on untouched base and are unrelated to this change; the full suite is not being represented as green.

## Scope and limitations

This change has not been validated with a live Premium-grid upload or captured HTTP request body. It does not change separate `AssetManager` payment behavior or non-texture zero-pricing behavior.

## Related issues

Fixes #171
