### PR TITLE
Wrap GLTF material inventory uploads in binary LLSD

### DIFF
--- a/LibreMetaverse.Tests/GLTFMaterialUploadTests.cs
+++ b/LibreMetaverse.Tests/GLTFMaterialUploadTests.cs
@@ -25,9 +25,12 @@
  */
 
 using System;
+using System.Linq;
 using System.Net;
+using System.Text;
 using System.Threading.Tasks;
 using LibreMetaverse.Assets;
+using LibreMetaverse.StructuredData;
 using LibreMetaverse.Tests.TestHelpers;
 using NUnit.Framework;
 
@@ -38,9 +41,9 @@ namespace LibreMetaverse.Tests
     /// Verified against the reference viewer (LLMaterialEditor::updateInventoryItem in
     /// llmaterialeditor.cpp): a two-phase upload using the same LLBufferedAssetUploadInfo shape as
     /// UpdateNotecardAgentInventory/UpdateNotecardTaskInventory -- POST {"item_id"} (plus "task_id"
-    /// for the task variant) to the capability, which returns an "uploader" URL that the material's
-    /// GLTF JSON is then POSTed to; a final "state":"complete" response carries the new asset UUID
-    /// under "new_asset".
+    /// for the task variant) to the capability, which returns an "uploader" URL. The second POST
+    /// sends a binary LLSD map containing version, type, and the material JSON in data; a final
+    /// "state":"complete" response carries the new asset UUID under "new_asset".
     /// </summary>
     [TestFixture]
     public class GLTFMaterialUploadTests
@@ -66,7 +69,7 @@ namespace LibreMetaverse.Tests
         }
 
         [Test]
-        public async Task RequestUpdateMaterialAgentInventoryAsync_HappyPath_PostsMetadataThenJsonAndReturnsNewAsset()
+        public async Task RequestUpdateMaterialAgentInventoryAsync_HappyPath_PostsWrappedAssetAndReturnsNewAsset()
         {
             var itemId = UUID.Random();
             var newAsset = UUID.Random();
@@ -129,7 +132,7 @@ namespace LibreMetaverse.Tests
         }
 
         [Test]
-        public async Task RequestUpdateMaterialAgentInventoryAsync_UploadedJsonRoundTripsMaterial()
+        public async Task RequestUpdateMaterialAgentInventoryAsync_UploadedAssetIsBinaryLlsdWrappedGltf()
         {
             var itemId = UUID.Random();
             var newAsset = UUID.Random();
@@ -139,15 +142,32 @@ namespace LibreMetaverse.Tests
             _client.AddHttpResponse(new Uri(UploaderUrl), HttpStatusCode.OK,
                 $"{{\"state\":\"complete\",\"new_asset\":\"{newAsset}\"}}", "application/json");
 
-            var material = new AssetMaterial { Name = "My Material" };
+            var material = new AssetMaterial { Name = "My Material \u0394" };
             material.SetBaseColorFactor(new Color4(0.2f, 0.4f, 0.6f, 1f));
+            var expectedJson = material.ToJson();
             await _client.Inventory.RequestUpdateMaterialAgentInventoryAsync(material, itemId);
 
-            var uploadedJson = _client.CapturedRequests[1].Body;
-            var roundTripped = new AssetMaterial(UUID.Random(),
-                System.Text.Encoding.UTF8.GetBytes(uploadedJson));
+            var uploadedAsset = _client.CapturedRequestBodies[1];
+            var binaryHeader = Encoding.ASCII.GetBytes("<?llsd/binary?>\n");
+            Assert.That(uploadedAsset.Take(binaryHeader.Length), Is.EqualTo(binaryHeader));
+            Assert.That(Encoding.ASCII.GetString(uploadedAsset).IndexOf(
+                "<?llsd/binary?>", binaryHeader.Length, StringComparison.Ordinal), Is.EqualTo(-1));
 
-            Assert.That(roundTripped.Name, Is.EqualTo("My Material"));
+            var asset = OSDParser.DeserializeLLSDBinary(uploadedAsset);
+            Assert.That(asset, Is.TypeOf<OSDMap>());
+            var assetMap = (OSDMap)asset;
+            Assert.That(assetMap.Count, Is.EqualTo(3));
+            Assert.That(assetMap["version"].Type, Is.EqualTo(OSDType.String));
+            Assert.That(assetMap["version"].AsString(), Is.EqualTo("1.1"));
+            Assert.That(assetMap["type"].Type, Is.EqualTo(OSDType.String));
+            Assert.That(assetMap["type"].AsString(), Is.EqualTo("GLTF 2.0"));
+            Assert.That(assetMap["data"].Type, Is.EqualTo(OSDType.String));
+            Assert.That(assetMap["data"].AsString(), Is.EqualTo(expectedJson));
+
+            var roundTripped = new AssetMaterial(UUID.Random(),
+                Encoding.UTF8.GetBytes(assetMap["data"].AsString()));
+
+            Assert.That(roundTripped.Name, Is.EqualTo("My Material \u0394"));
             Assert.That(roundTripped.BaseColorFactor, Is.EqualTo(material.BaseColorFactor));
         }
     }

--- a/LibreMetaverse.Tests/TestHelpers/FakeGridClient.cs
+++ b/LibreMetaverse.Tests/TestHelpers/FakeGridClient.cs
@@ -19,6 +19,9 @@ namespace LibreMetaverse.Tests.TestHelpers
         /// <summary>All requests received, in order.</summary>
         public List<(HttpMethod Method, Uri Uri, string Body)> CapturedRequests { get; } = new List<(HttpMethod, Uri, string)>();
 
+        /// <summary>Raw request bodies received, in the same order as <see cref="CapturedRequests"/>.</summary>
+        public List<byte[]> CapturedRequestBodies { get; } = new List<byte[]>();
+
         /// <summary>Register a response matched by exact URI string.</summary>
         public void AddResponse(Uri uri, HttpStatusCode status, string content, string mediaType = "application/json")
         {
@@ -34,11 +37,18 @@ namespace LibreMetaverse.Tests.TestHelpers
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var body = string.Empty;
+            var bodyBytes = Array.Empty<byte>();
             if (request?.Content != null)
+            {
                 body = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                bodyBytes = await request.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+            }
 
             if (request?.RequestUri != null)
+            {
                 CapturedRequests.Add((request.Method, request.RequestUri, body));
+                CapturedRequestBodies.Add(bodyBytes);
+            }
 
             // Exact match
             if (request?.RequestUri != null && _responses.TryGetValue(request.RequestUri.ToString(), out var entry))
@@ -102,6 +112,9 @@ namespace LibreMetaverse.Tests.TestHelpers
 
         /// <summary>All HTTP requests received by this client, in order.</summary>
         public List<(HttpMethod Method, Uri Uri, string Body)> CapturedRequests => _fakeHandler.CapturedRequests;
+
+        /// <summary>Raw HTTP request bodies received, in the same order as <see cref="CapturedRequests"/>.</summary>
+        public List<byte[]> CapturedRequestBodies => _fakeHandler.CapturedRequestBodies;
 
         /// <summary>
         /// Injects an arbitrary named capability URI into CurrentSim's Caps, creating a fake

--- a/LibreMetaverse.Tests/TestHelpers/FakeGridClient.cs
+++ b/LibreMetaverse.Tests/TestHelpers/FakeGridClient.cs
@@ -40,8 +40,13 @@ namespace LibreMetaverse.Tests.TestHelpers
             var bodyBytes = Array.Empty<byte>();
             if (request?.Content != null)
             {
+#if NET5_0_OR_GREATER
+                body = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                bodyBytes = await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+#else
                 body = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
                 bodyBytes = await request.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+#endif
             }
 
             if (request?.RequestUri != null)

--- a/LibreMetaverse/Inventory/InventoryManager.Async.cs
+++ b/LibreMetaverse/Inventory/InventoryManager.Async.cs
@@ -302,11 +302,10 @@ namespace LibreMetaverse
         /// Saves a GLTF material to an existing agent inventory item via the
         /// UpdateMaterialAgentInventory capability. Mirrors
         /// LLMaterialEditor::updateInventoryItem's agent-inventory branch (llmaterialeditor.cpp): a
-        /// two-phase upload where the metadata POST (item_id) returns an "uploader" URL that the
-        /// material's minified GLTF JSON is then POSTed to.
+        /// two-phase upload where the metadata POST (item_id) returns an "uploader" URL. The second
+        /// POST sends a binary LLSD map containing version, type, and the material JSON in data.
         /// </summary>
-        /// <param name="material">The material to save; its JSON encoding (<see cref="AssetMaterial.ToJson"/>)
-        /// is what gets uploaded</param>
+        /// <param name="material">The material to save</param>
         /// <param name="materialItemID">UUID of the existing inventory item to update</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <param name="progress">Optional upload progress reporter</param>
@@ -319,7 +318,7 @@ namespace LibreMetaverse
             if (cap == null)
                 throw new InvalidOperationException("UpdateMaterialAgentInventory capability is not currently available");
 
-            var data = System.Text.Encoding.UTF8.GetBytes(material.ToJson());
+            var data = EncodeMaterialAsset(material);
             var query = new OSDMap { { "item_id", OSD.FromUUID(materialItemID) } };
             try
             {
@@ -333,10 +332,10 @@ namespace LibreMetaverse
         /// <summary>
         /// Saves a GLTF material to an existing task (object) inventory item via the
         /// UpdateMaterialTaskInventory capability. Mirrors
-        /// LLMaterialEditor::updateInventoryItem's task-inventory branch (llmaterialeditor.cpp).
+        /// LLMaterialEditor::updateInventoryItem's task-inventory branch (llmaterialeditor.cpp) and
+        /// uses the same two-phase binary LLSD material envelope as the agent-inventory path.
         /// </summary>
-        /// <param name="material">The material to save; its JSON encoding (<see cref="AssetMaterial.ToJson"/>)
-        /// is what gets uploaded</param>
+        /// <param name="material">The material to save</param>
         /// <param name="materialItemID">UUID of the existing task-inventory item to update</param>
         /// <param name="taskID">UUID of the object (task) containing the item</param>
         /// <param name="cancellationToken">Cancellation token</param>
@@ -350,7 +349,7 @@ namespace LibreMetaverse
             if (cap == null)
                 throw new InvalidOperationException("UpdateMaterialTaskInventory capability is not currently available");
 
-            var data = System.Text.Encoding.UTF8.GetBytes(material.ToJson());
+            var data = EncodeMaterialAsset(material);
             var query = new OSDMap { { "item_id", OSD.FromUUID(materialItemID) }, { "task_id", OSD.FromUUID(taskID) } };
             try
             {
@@ -359,6 +358,17 @@ namespace LibreMetaverse
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex) { return (false, ex.Message, UUID.Zero, UUID.Zero); }
+        }
+
+        private static byte[] EncodeMaterialAsset(AssetMaterial material)
+        {
+            var asset = new OSDMap
+            {
+                ["version"] = OSD.FromString("1.1"),
+                ["type"] = OSD.FromString("GLTF 2.0"),
+                ["data"] = OSD.FromString(material.ToJson())
+            };
+            return OSDParser.SerializeLLSDBinary(asset);
         }
 
         public async Task<(bool uploadSuccess, string uploadStatus, bool compileSuccess, List<string>? compileMessages, UUID itemID, UUID assetID)> RequestUpdateScriptAgentInventoryAsync(


### PR DESCRIPTION
## Summary

- encode the second-stage agent and task material inventory uploads as binary LLSD
- carry `version`, `type`, and the material JSON in the envelope `data` field
- preserve the existing two-stage capability flow
- add deterministic request-body coverage for the actual uploaded asset

## Motivation

LibreMetaverse currently uploads raw GLTF JSON during the second stage, but the capability verifier expects the viewer-compatible binary LLSD material envelope. Wrapping the JSON as `version`, `type`, and `data` matches the reference viewer behavior and allows the upload to complete.

## Validation

- exact binary-LLSD regression passed on net8.0, net9.0, and net10.0
- complete `GLTFMaterialUploadTests` fixture passed 4/4 on net481, net8.0, net9.0, and net10.0 after the cancellation-token compatibility fix
- net9.0 material/BinarySD neighboring group passed 51/51
- net9.0 inventory/upload neighboring group passed 25/25
- affected net9.0 Release build passed with 0 warnings and 0 errors
- previously completed full net10.0 candidate and untouched-base controls each passed 1211 tests with 19 skipped and 0 failed
- repository CI passed its full cross-platform and multi-framework matrix on the original candidate
- `git diff --check` passed

A separate full net9.0 suite was not run locally; local net9.0 validation was bounded to the affected fixture, exact regression, neighboring groups, and affected library build. Repository CI runs the complete cross-platform test matrix.

## Breaking changes

None. This PR does not remove or rename any public API.

## Limitations

- no live-grid upload was performed
- the compact LibreMetaverse binary header versus viewer spelling was not independently tested against a live server
- a possible viewer-buffer trailing NUL was not independently tested

## Related issues

Fixes #172