### PR TITLE
Fix visual parameter wire serialization

### DIFF
--- a/LibreMetaverse.Tests/AppearanceManagerTests.cs
+++ b/LibreMetaverse.Tests/AppearanceManagerTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using NUnit.Framework;
 
 namespace LibreMetaverse.Tests
@@ -5,6 +6,30 @@ namespace LibreMetaverse.Tests
     [TestFixture]
     public class AppearanceManagerTests
     {
+        [Test]
+        public void MakeAppearancePacket_UsesCompleteVisualParamWireSequence()
+        {
+            var client = new GridClient();
+            var packet = client.Appearance.MakeAppearancePacket();
+            var wireParamIds = VisualParams.Group0ParamIds;
+            var expectedValues = wireParamIds
+                .Select(id => VisualParams.Params[id])
+                .Select(param => Utils.FloatToByte(param.DefaultValue, param.MinValue, param.MaxValue))
+                .ToArray();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(wireParamIds, Has.Length.EqualTo(253));
+                Assert.That(wireParamIds, Is.Ordered);
+                Assert.That(wireParamIds.Distinct().Count(), Is.EqualTo(wireParamIds.Length));
+                Assert.That(wireParamIds.All(id =>
+                    VisualParams.Params.TryGetValue(id, out var param) &&
+                    (param.Group == 0 || param.Group == 3)), Is.True);
+                Assert.That(packet.VisualParam.Select(block => block.ParamValue),
+                    Is.EqualTo(expectedValues));
+            });
+        }
+
         [Test]
         public void WearableTypeToAssetType_BodypartsAndClothing_ReturnsExpected()
         {

--- a/LibreMetaverse.Tests/AppearanceTests.cs
+++ b/LibreMetaverse.Tests/AppearanceTests.cs
@@ -70,8 +70,8 @@ namespace LibreMetaverse.Tests
         [Test]
         public void DecodeVisualParams_RoundTrip_DefaultValues()
         {
-            // Build the byte array in Group0ParamIds document order — this is the order
-            // DecodeVisualParams consumes, which differs from the SortedList key order.
+            // Build the byte array in Group0ParamIds wire order — this is the order
+            // DecodeVisualParams consumes.
             var bytes = VisualParams.Group0ParamIds
                 .Select(id => VisualParams.Params.TryGetValue(id, out var vp)
                     ? Utils.FloatToByte(vp.DefaultValue, vp.MinValue, vp.MaxValue)
@@ -176,7 +176,7 @@ namespace LibreMetaverse.Tests
         [Test]
         public void AvatarAppearanceEventArgs_DecodeVisualParams_RoundTrip_DefaultValues()
         {
-            // Build bytes in Group0ParamIds document order — this is the order DecodeVisualParams consumes.
+            // Build bytes in Group0ParamIds wire order — this is the order DecodeVisualParams consumes.
             var bytes = VisualParams.Group0ParamIds
                 .Select(id => VisualParams.Params.TryGetValue(id, out var vp)
                     ? Utils.FloatToByte(vp.DefaultValue, vp.MinValue, vp.MaxValue)

--- a/LibreMetaverse/Appearance/AppearanceManager.cs
+++ b/LibreMetaverse/Appearance/AppearanceManager.cs
@@ -2484,16 +2484,12 @@ namespace LibreMetaverse
             {
                 #region VisualParam
 
-                var vpIndex = 0;
-                var wearingPhysics = Wearables.ContainsKey(WearableType.Physics);
+                var wireParamIds = VisualParams.Group0ParamIds;
+                set.VisualParam = new AgentSetAppearancePacket.VisualParamBlock[wireParamIds.Length];
 
-                var nrParams = wearingPhysics ? 251 : 218;
-                set.VisualParam = new AgentSetAppearancePacket.VisualParamBlock[nrParams];
-
-                foreach (var kvp in VisualParams.Params)
+                for (var vpIndex = 0; vpIndex < wireParamIds.Length; ++vpIndex)
                 {
-                    if (vpIndex >= nrParams) break;
-                    var vp = kvp.Value;
+                    var vp = VisualParams.Params[wireParamIds[vpIndex]];
 
                     var paramValue = 0f;
                     var found = Wearables.Any(wearableList => wearableList.Value.Any(wearable => wearable.Asset != null && wearable.Asset.Params.TryGetValue(vp.ParamID, out paramValue)));
@@ -2505,7 +2501,6 @@ namespace LibreMetaverse
                     {
                         ParamValue = Utils.FloatToByte(paramValue, vp.MinValue, vp.MaxValue)
                     };
-                    ++vpIndex;
 
                     // Check if this is one of the visual params used in the agent height calculation
                     switch (vp.ParamID)

--- a/LibreMetaverse/Avatar.cs
+++ b/LibreMetaverse/Avatar.cs
@@ -498,7 +498,7 @@ namespace LibreMetaverse
         /// </summary>
         /// <remarks>
         /// The AvatarAppearance packet transmits both TWEAKABLE (group-0) and
-        /// TRANSMIT_NOT_TWEAKABLE (group-3) params interleaved in avatar_lad.xml document order.
+        /// TRANSMIT_NOT_TWEAKABLE (group-3) params interleaved in ascending numeric ID order.
         /// <see cref="VisualParams.Group0ParamIds"/> includes both groups in that order so each
         /// byte maps to the correct parameter.
         /// </remarks>
@@ -662,4 +662,3 @@ namespace LibreMetaverse
 
     }
 }
-

--- a/SourceGenerators/VisualParamGenerator/VisualParamGenerator.cs
+++ b/SourceGenerators/VisualParamGenerator/VisualParamGenerator.cs
@@ -294,7 +294,7 @@ namespace LibreMetaverse
         public static SortedList<int, VisualParam> Params = new SortedList<int, VisualParam>();
 
         /// <summary>
-        /// Group-0 parameter IDs in the exact order they appear in avatar_lad.xml.
+        /// Group-0 and group-3 parameter IDs in ascending numeric ID order.
         /// This order matches the byte sequence in the AvatarAppearance packet visual_param block.
         /// </summary>
         public static int[] Group0ParamIds = Array.Empty<int>();
@@ -382,7 +382,7 @@ namespace LibreMetaverse
             var nodes = doc.GetElementsByTagName("param");
 
             var ids = new SortedList<int, string>();
-            var group0IdsInOrder = new List<int>();  // group-0 and group-3 (TRANSMIT_NOT_TWEAKABLE) IDs in avatar_lad.xml document order
+            var group0IdsInOrder = new List<int>();  // group-0 and group-3 (TRANSMIT_NOT_TWEAKABLE) wire IDs
             var alphas = new Dictionary<int, string>();
             var colors = new Dictionary<int, string>();
             var drivenParamInfoMap = new Dictionary<int, string>();
@@ -640,7 +640,7 @@ namespace LibreMetaverse
                     {
                         // group-3 (VISUAL_PARAM_GROUP_TRANSMIT_NOT_TWEAKABLE) params are also
                         // transmitted in the AvatarAppearance packet interleaved with group-0 params
-                        // in avatar_lad.xml document order. They must be included here so that
+                        // in ascending numeric ID order. They must be included here so that
                         // DecodeVisualParams() reads each byte from the correct offset.
                         group0IdsInOrder.Add(id);
                     }


### PR DESCRIPTION
## Description

Make `AppearanceManager.MakeAppearancePacket()` serialize the complete generated visual-parameter wire sequence instead of truncating it to 218 entries, or 251 when physics is worn.

## Motivation

`AgentSetAppearance.VisualParam` is positional. Truncating the sequence shifts later values onto unrelated sliders, which can deform avatar bodies on OpenSim. Using `VisualParams.Group0ParamIds` keeps packet membership, ordering, and length aligned with the generated wire table.

## Changes

- Derive the outgoing visual-parameter count from `VisualParams.Group0ParamIds`.
- Serialize every value in the generated ascending-ID wire order.
- Add regression coverage for the 253-entry ordered, unique group-0/group-3 sequence.
- Align related comments with the actual wire ordering.

## Testing

- Release solution build completed with no errors and no warnings from changed lines.
- Focused appearance serialization and decode tests passed on net481, net8.0, net9.0, and net10.0.
- Complete `LibreMetaverse.Tests` suite: 4,232 passed; 76 live-grid tests skipped.
- Complete rendering suite: 225 passed.
- Local OpenSim validation confirmed 253 visual parameters after login, adjacent-region crossing, and inter-region teleport; observer visual check passed.

## Breaking changes

None.

## Related issues

Fixes #176